### PR TITLE
fix: update validate-migration taskRef

### DIFF
--- a/.tekton/integration/pipeline.yaml
+++ b/.tekton/integration/pipeline.yaml
@@ -64,8 +64,8 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/14rcole/konflux-test-tasks.git #TODO: update to konflux-ci org before merging
+            value: https://github.com/konflux-ci/konflux-test-tasks.git
           - name: revision
-            value: stoneintg-1235 #TODO: Update to main before merging
+            value: main
           - name: pathInRepo
             value: .tekton/integration/validate-migration.yaml


### PR DESCRIPTION
Update taskRef for validate-migration script from fork of this repo (14rcole org) to main repo (konflux-ci org)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
