### PR TITLE
Limit push builds to task/ directory changes

### DIFF
--- a/.tekton/clair-scan-v02-push.yaml
+++ b/.tekton/clair-scan-v02-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "/task/clair-scan/0.2/***".pathChanged() || ".tekton/clair-scan-v02-push.yaml".pathChanged() || ".tekton/integration/***".pathChanged()
-      )
+      == "main" && "/task/clair-scan/0.2/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-test-tasks

--- a/.tekton/clamav-scan-v02-push.yaml
+++ b/.tekton/clamav-scan-v02-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/clamav-scan/0.2/***".pathChanged() || ".tekton/clamav-scan-v02-push.yaml".pathChanged() || ".tekton/integration/***".pathChanged()
-      )
+      == "main" && "task/clamav-scan/0.2/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-test-tasks

--- a/.tekton/deprecated-image-check-v05-push.yaml
+++ b/.tekton/deprecated-image-check-v05-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/deprecated-image-check/0.5/***".pathChanged() || ".tekton/deprecated-image-check-v05-push.yaml".pathChanged() || ".tekton/integration/***".pathChanged()
-      )
+      == "main" && "task/deprecated-image-check/0.5/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-test-tasks


### PR DESCRIPTION
# Before you complete this pull request ...

The current configuration is generating new bundles whenever the build pipeline itself is changed, such as with new konflux reference updates.

The ReleasePlan for these tasks is an autoreleasing one, so this is constantly updating the bundle on quay without any changes to the actual yaml file on the tekton bundle.

Limit the push pipeline runs to changes on the task files to avoid unnecessary noise republishing the same task over and over again
