### PR TITLE
fix(STONEINTG-1551): use select-oci-auth for oras attach

### DIFF
--- a/task/clair-scan-min/0.3/clair-scan-min.yaml
+++ b/task/clair-scan-min/0.3/clair-scan-min.yaml
@@ -246,9 +246,11 @@ spec:
       for f in clair-report-*.json; do
         digest=$(cat "image-manifest-$(arch "$f").sha")
         image_ref="${repository}@${digest}"
+        mkdir -p /tmp/auth && select-oci-auth "${image_ref}" > /tmp/auth/config.json
+        export DOCKER_CONFIG=/tmp/auth
         echo "Attaching $f to ${image_ref}"
         if ! report_digest="$(retry oras attach --no-tty --format go-template='{{.digest}}' --registry-config \
-          "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${image_ref}" "$f:${MEDIA_TYPE}")"
+          "/tmp/auth/config.json" --artifact-type "${MEDIA_TYPE}" "${image_ref}" "$f:${MEDIA_TYPE}")"
         then
           echo "Failed to attach ${f} to ${image_ref}"
           exit 1

--- a/task/clair-scan/0.3/clair-scan.yaml
+++ b/task/clair-scan/0.3/clair-scan.yaml
@@ -246,9 +246,11 @@ spec:
         for f in clair-report-*.json; do
           digest=$(cat "image-manifest-$(arch "$f").sha")
           image_ref="${repository}@${digest}"
+          mkdir -p /tmp/auth && select-oci-auth "${image_ref}" > /tmp/auth/config.json
+          export DOCKER_CONFIG=/tmp/auth
           echo "Attaching $f to ${image_ref}"
           if ! report_digest="$(retry oras attach --no-tty --format go-template='{{.digest}}' --registry-config \
-            "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${image_ref}" "$f:${MEDIA_TYPE}")"
+            "/tmp/auth/config.json" --artifact-type "${MEDIA_TYPE}" "${image_ref}" "$f:${MEDIA_TYPE}")"
           then
             echo "Failed to attach ${f} to ${image_ref}"
             exit 1

--- a/task/roxctl-scan/0.1/roxctl-scan.yaml
+++ b/task/roxctl-scan/0.1/roxctl-scan.yaml
@@ -242,9 +242,11 @@ spec:
         for f in image-manifest-*.sha; do
           digest=$(cat "image-manifest-$(arch "$f")")
           image_ref="${repository}@${digest}"
+          mkdir -p /tmp/auth && select-oci-auth "${image_ref}" > /tmp/auth/config.json
+          export DOCKER_CONFIG=/tmp/auth
           echo "Attaching $f to ${image_ref}"
           if ! report_digest="$(retry oras attach --no-tty --format go-template='{{.digest}}' --registry-config \
-            "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${image_ref}" "$f:${MEDIA_TYPE}")"
+            "/tmp/auth/config.json" --artifact-type "${MEDIA_TYPE}" "${image_ref}" "$f:${MEDIA_TYPE}")"
           then
             echo "Failed to attach ${f} to ${image_ref}"
             exit 1


### PR DESCRIPTION
* Run the select-oci-auth script for all oras attach calls in the latest versions of the tasks
* This ensures that the correct credentials are used by the oras tool

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
