### PR TITLE
fix: add --confirm to oc image extract to allow retry on 502

### DIFF
--- a/task/clamav-scan-min/0.3/clamav-scan-min.yaml
+++ b/task/clamav-scan-min/0.3/clamav-scan-min.yaml
@@ -294,7 +294,7 @@ spec:
           arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)
 
           echo "Running \"oc image extract\" on image of arch $arch"
-          retry oc image extract --only-files=true --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"
+          retry oc image extract --confirm --only-files=true --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"
           if [ $? -ne 0 ]; then
             echo "Unable to extract image for arch $arch. Skipping ClamAV scan!"
             exit 0

--- a/task/clamav-scan/0.3/clamav-scan.yaml
+++ b/task/clamav-scan/0.3/clamav-scan.yaml
@@ -301,7 +301,7 @@ spec:
             arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)
 
             echo "Running \"oc image extract\" on image of arch $arch"
-            retry oc image extract --only-files=true --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"
+            retry oc image extract --confirm --only-files=true --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"
             if [ $? -ne 0 ]; then
               echo "Unable to extract image for arch $arch. Skipping ClamAV scan!"
               exit 0


### PR DESCRIPTION
When `oc image extract` fails mid-transfer (e.g. 502 Bad Gateway), the
destination directory retains partial content. Subsequent retries fail
with `directory must be empty, pass --confirm to overwrite contents`.

Add `--confirm` flag so retries can overwrite the partial content and
complete successfully.

```
Detecting artifact type for quay.io/...tomcat-11--hummingbird--builder@sha256:3e6457...
Detected container image. Processing image manifests.
Running "oc image extract" on image of arch amd64
error: unable to access the source layer sha256:fe515f...: received unexpected HTTP status: 502 Bad Gateway
info: Retrying again in 5 seconds...
error: directory /work/content/content-amd64 must be empty, pass --confirm to overwrite contents of directory
info: Retrying again in 5 seconds...
error: directory /work/content/content-amd64 must be empty, pass --confirm to overwrite contents of directory
{"result":"ERROR","note":"Unexpected error: Script errored at command: return \"$\{status\}\".",...}
```