### PR TITLE
feat(STONEINTG-1543): resolve checkton and shellcheck issues

### DIFF
--- a/task/clair-scan-min/0.3/clair-scan-min.yaml
+++ b/task/clair-scan-min/0.3/clair-scan-min.yaml
@@ -72,12 +72,12 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
-      # shellcheck source=/dev/null
+      # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
       . /utils.sh
 
-      imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
+      imagewithouttag=$(echo -n "$IMAGE_URL" | sed "s/\(.*\):.*/\1/")
       # strip new-line escape symbol from parameter and save it to variable
-      imageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)
+      imageanddigest="${imagewithouttag}@${IMAGE_DIGEST}"
       echo "Inspecting raw image manifest $imageanddigest."
 
       # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
@@ -86,7 +86,7 @@ spec:
       image_manifests=$(get_image_manifests -i "${imageanddigest}")
       if [ -n "$image_manifests" ]; then
         echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"' | while read -r arch arch_sha; do
-          echo "$arch_sha" > /tekton/home/image-manifest-$arch.sha
+          echo "$arch_sha" > "/tekton/home/image-manifest-${arch}.sha"
         done
       else
         echo "Failed to get image manifests from image \"$imageanddigest\""
@@ -122,13 +122,13 @@ spec:
       set -o errexit
       set -o nounset
       set -o pipefail
-      # shellcheck source=/utils.sh
+      # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
       . /utils.sh
 
       mkdir -p /tmp/auth && select-oci-auth "$IMAGE_URL" > /tmp/auth/config.json
       export DOCKER_CONFIG=/tmp/auth
 
-      imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
+      imagewithouttag=$(echo -n "$IMAGE_URL" | sed "s/\(.*\):.*/\1/")
       images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
       digests_processed=()
 
@@ -193,7 +193,7 @@ spec:
       fi
       digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
 
-      images_processed=$(echo "${images_processed_template/\[%s]/[$digests_processed_string]}")
+      images_processed="${images_processed_template/\[%s]/[$digests_processed_string]}"
       echo "$images_processed" > images-processed.json
     workingDir: /tekton/home
   - computeResources:
@@ -272,6 +272,7 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
+      # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
       . /utils.sh
       trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
@@ -286,9 +287,9 @@ spec:
         if [ ! -s "$file" ]; then
           echo "Previous step [get-vulnerabilities] failed: $file is empty."
         else
-          /usr/bin/conftest test --no-fail $file \
+          /usr/bin/conftest test --no-fail "$file" \
           --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \
-          --output=json | tee /tekton/home/clair-vulnerabilities-$file_suffix.json || true
+          --output=json | tee "/tekton/home/clair-vulnerabilities-${file_suffix}.json" || true
         fi
 
         #check for missing "clair-vulnerabilities-<arch>/image-index" file and create a string
@@ -301,7 +302,7 @@ spec:
         note="Task $(context.task.name) failed: $missing_vulnerabilities_files did not generate. For details, check Tekton task log."
         TEST_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
         echo "$missing_vulnerabilities_files did not generate correctly. For details, check conftest command in Tekton task log."
-        echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
         exit 0
       fi
 
@@ -341,13 +342,13 @@ spec:
 
       echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"
 
-      cat /tekton/home/images-processed.json | tee $(results.IMAGES_PROCESSED.path)
+      tee "$(results.IMAGES_PROCESSED.path)" < /tekton/home/images-processed.json
       # shellcheck disable=SC2154
       cat /tekton/home/reports.json > "$(results.REPORTS.path)"
 
       note="Task $(context.task.name) completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair."
       TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")
-      echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+      echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
     securityContext:
       capabilities:
         add:

--- a/task/clair-scan/0.3/clair-scan.yaml
+++ b/task/clair-scan/0.3/clair-scan.yaml
@@ -75,12 +75,12 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
-        # shellcheck source=/dev/null
+        # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
         . /utils.sh
 
-        imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
+        imagewithouttag=$(echo -n "$IMAGE_URL" | sed "s/\(.*\):.*/\1/")
         # strip new-line escape symbol from parameter and save it to variable
-        imageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)
+        imageanddigest="${imagewithouttag}@${IMAGE_DIGEST}"
         echo "Inspecting raw image manifest $imageanddigest."
 
         # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
@@ -89,7 +89,7 @@ spec:
         image_manifests=$(get_image_manifests -i "${imageanddigest}")
         if [ -n "$image_manifests" ]; then
           echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"' | while read -r arch arch_sha; do
-            echo "$arch_sha" > /tekton/home/image-manifest-$arch.sha
+            echo "$arch_sha" > "/tekton/home/image-manifest-${arch}.sha"
           done
         else
           echo "Failed to get image manifests from image \"$imageanddigest\""
@@ -122,13 +122,13 @@ spec:
         set -o errexit
         set -o nounset
         set -o pipefail
-        # shellcheck source=/utils.sh
+        # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
         . /utils.sh
 
         mkdir -p /tmp/auth && select-oci-auth "$IMAGE_URL" > /tmp/auth/config.json
         export DOCKER_CONFIG=/tmp/auth
 
-        imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
+        imagewithouttag=$(echo -n "$IMAGE_URL" | sed "s/\(.*\):.*/\1/")
         images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
         digests_processed=()
 
@@ -193,7 +193,7 @@ spec:
         fi
         digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
 
-        images_processed=$(echo "${images_processed_template/\[%s]/[$digests_processed_string]}")
+        images_processed="${images_processed_template/\[%s]/[$digests_processed_string]}"
         echo "$images_processed" > images-processed.json
     - name: oci-attach-report
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
@@ -277,6 +277,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+        # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
         . /utils.sh
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
@@ -291,9 +292,9 @@ spec:
           if [ ! -s "$file" ]; then
             echo "Previous step [get-vulnerabilities] failed: $file is empty."
           else
-            /usr/bin/conftest test --no-fail $file \
+            /usr/bin/conftest test --no-fail "$file" \
             --policy /project/clair/vulnerabilities-check.rego --namespace required_checks \
-            --output=json | tee /tekton/home/clair-vulnerabilities-$file_suffix.json || true
+            --output=json | tee "/tekton/home/clair-vulnerabilities-${file_suffix}.json" || true
           fi
 
           #check for missing "clair-vulnerabilities-<arch>/image-index" file and create a string
@@ -306,7 +307,7 @@ spec:
           note="Task $(context.task.name) failed: $missing_vulnerabilities_files did not generate. For details, check Tekton task log."
           TEST_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
           echo "$missing_vulnerabilities_files did not generate correctly. For details, check conftest command in Tekton task log."
-          echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
           exit 0
         fi
 
@@ -346,13 +347,13 @@ spec:
 
         echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"
 
-        cat /tekton/home/images-processed.json | tee $(results.IMAGES_PROCESSED.path)
+        tee "$(results.IMAGES_PROCESSED.path)" < /tekton/home/images-processed.json
         # shellcheck disable=SC2154
         cat /tekton/home/reports.json > "$(results.REPORTS.path)"
 
         note="Task $(context.task.name) completed: Refer to Tekton task result SCAN_OUTPUT for vulnerabilities scanned by Clair."
         TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")
-        echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
   volumes:
   - name: trusted-ca
     configMap:

--- a/task/clamav-scan-min/0.3/clamav-scan-min.yaml
+++ b/task/clamav-scan-min/0.3/clamav-scan-min.yaml
@@ -67,6 +67,7 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
+      # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
       . /utils.sh
       trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
@@ -80,10 +81,10 @@ spec:
           echo '{}' > ~/.docker/config.json
       fi
 
-      imagewithouttag=$(echo $IMAGE_URL | sed "s/\(.*\):.*/\1/" | tr -d '\n')
+      imagewithouttag=$(echo "$IMAGE_URL" | sed "s/\(.*\):.*/\1/" | tr -d '\n')
 
       # strip new-line escape symbol from parameter and save it to variable
-      imageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)
+      imageanddigest="${imagewithouttag}@${IMAGE_DIGEST}"
 
       # check if image is attestation one, skip the clamav scan in such case
       if [[ $imageanddigest == *.att ]]
@@ -289,13 +290,12 @@ spec:
         fi
 
         while read -r arch arch_sha; do
-          destination=$(echo content-$arch)
+          destination="content-${arch}"
           mkdir -p "$destination"
-          arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)
+          arch_imageanddigest="${imagewithouttag}@${arch_sha}"
 
           echo "Running \"oc image extract\" on image of arch $arch"
-          retry oc image extract --confirm --only-files=true --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"
-          if [ $? -ne 0 ]; then
+          if ! retry oc image extract --confirm --only-files=true --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"; then
             echo "Unable to extract image for arch $arch. Skipping ClamAV scan!"
             exit 0
           fi
@@ -315,7 +315,7 @@ spec:
           "warnings" : (.warnings + $item.warnings),
           "result" : (if .result == "" or ($item.result == "SKIPPED" and .result == "SUCCESS") or ($item.result == "WARNING" and (.result == "SUCCESS" or .result == "SKIPPED")) or ($item.result == "FAILURE" and .result != "ERROR") or $item.result == "ERROR" then $item.result else .result end),
           "note" : (if .result == "" or ($item.result == "SKIPPED" and .result == "SUCCESS") or ($item.result == "WARNING" and (.result == "SUCCESS" or .result == "SKIPPED")) or ($item.result == "FAILURE" and .result != "ERROR") or $item.result == "ERROR" then $item.note else .note end)
-          })' /work/logs/clamscan-ec-test-*.json | tee $(results.TEST_OUTPUT.path)
+          })' /work/logs/clamscan-ec-test-*.json | tee "$(results.TEST_OUTPUT.path)"
 
       # If the image is an Image Index, also add the Image Index digest to the list.
       if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
@@ -323,7 +323,7 @@ spec:
       fi
 
       digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
-      echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee $(results.IMAGES_PROCESSED.path)
+      echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee "$(results.IMAGES_PROCESSED.path)"
     securityContext:
       capabilities:
         add:
@@ -376,13 +376,13 @@ spec:
         args+=("${UPLOAD_FILE}:${MEDIA_TYPE}")
       done
 
-      if [ -z "${args}" ]; then
+      if [ ${#args[@]} -eq 0 ]; then
         echo "No files found. Skipping upload."
         exit 0;
       fi
 
       echo "Selecting auth"
-      select-oci-auth $IMAGE_URL > $HOME/auth.json
+      select-oci-auth "$IMAGE_URL" > "$HOME/auth.json"
       echo "Attaching to ${IMAGE_URL}"
        retry oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type application/vnd.clamav "${IMAGE_URL}@${IMAGE_DIGEST}" "${args[@]}"
     volumeMounts:

--- a/task/clamav-scan/0.3/clamav-scan.yaml
+++ b/task/clamav-scan/0.3/clamav-scan.yaml
@@ -74,6 +74,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+        # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
         . /utils.sh
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
@@ -87,10 +88,10 @@ spec:
             echo '{}' > ~/.docker/config.json
         fi
 
-        imagewithouttag=$(echo $IMAGE_URL | sed "s/\(.*\):.*/\1/" | tr -d '\n')
+        imagewithouttag=$(echo "$IMAGE_URL" | sed "s/\(.*\):.*/\1/" | tr -d '\n')
 
         # strip new-line escape symbol from parameter and save it to variable
-        imageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)
+        imageanddigest="${imagewithouttag}@${IMAGE_DIGEST}"
 
         # check if image is attestation one, skip the clamav scan in such case
         if [[ $imageanddigest == *.att ]]
@@ -296,13 +297,12 @@ spec:
           fi
 
           while read -r arch arch_sha; do
-            destination=$(echo content-$arch)
+            destination="content-${arch}"
             mkdir -p "$destination"
-            arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)
+            arch_imageanddigest="${imagewithouttag}@${arch_sha}"
 
             echo "Running \"oc image extract\" on image of arch $arch"
-            retry oc image extract --confirm --only-files=true --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"
-            if [ $? -ne 0 ]; then
+            if ! retry oc image extract --confirm --only-files=true --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"; then
               echo "Unable to extract image for arch $arch. Skipping ClamAV scan!"
               exit 0
             fi
@@ -322,7 +322,7 @@ spec:
             "warnings" : (.warnings + $item.warnings),
             "result" : (if .result == "" or ($item.result == "SKIPPED" and .result == "SUCCESS") or ($item.result == "WARNING" and (.result == "SUCCESS" or .result == "SKIPPED")) or ($item.result == "FAILURE" and .result != "ERROR") or $item.result == "ERROR" then $item.result else .result end),
             "note" : (if .result == "" or ($item.result == "SKIPPED" and .result == "SUCCESS") or ($item.result == "WARNING" and (.result == "SUCCESS" or .result == "SKIPPED")) or ($item.result == "FAILURE" and .result != "ERROR") or $item.result == "ERROR" then $item.note else .note end)
-            })' /work/logs/clamscan-ec-test-*.json | tee $(results.TEST_OUTPUT.path)
+            })' /work/logs/clamscan-ec-test-*.json | tee "$(results.TEST_OUTPUT.path)"
 
         # If the image is an Image Index, also add the Image Index digest to the list.
         if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
@@ -330,7 +330,7 @@ spec:
         fi
 
         digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
-        echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee $(results.IMAGES_PROCESSED.path)
+        echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee "$(results.IMAGES_PROCESSED.path)"
       volumeMounts:
         - mountPath: /work
           name: work
@@ -379,13 +379,13 @@ spec:
           args+=("${UPLOAD_FILE}:${MEDIA_TYPE}")
         done
 
-        if [ -z "${args}" ]; then
+        if [ ${#args[@]} -eq 0 ]; then
           echo "No files found. Skipping upload."
           exit 0;
         fi
 
         echo "Selecting auth"
-        select-oci-auth $IMAGE_URL > $HOME/auth.json
+        select-oci-auth "$IMAGE_URL" > "$HOME/auth.json"
         echo "Attaching to ${IMAGE_URL}"
          retry oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type application/vnd.clamav "${IMAGE_URL}@${IMAGE_DIGEST}" "${args[@]}"
       volumeMounts:

--- a/task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -66,6 +66,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+        # shellcheck disable=SC1091 # /utils.sh is only available in the container image at runtime
         source /utils.sh
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
@@ -80,24 +81,23 @@ spec:
         images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
         digests_processed=()
 
-        imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
+        imagewithouttag=$(echo -n "$IMAGE_URL" | sed "s/\(.*\):.*/\1/")
         # strip new-line escape symbol from parameter and save it to variable
-        imageanddigest=$(echo -n $imagewithouttag@$IMAGE_DIGEST)
+        imageanddigest="${imagewithouttag}@${IMAGE_DIGEST}"
 
         # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
         image_manifests=$(get_image_manifests -i "${imageanddigest}")
         if [ -n "$image_manifests" ]; then
           while read -r arch arch_sha; do
-            SBOM_FILE_PATH=$(echo "/tmp/sbom-$arch.json")
-            arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)
+            SBOM_FILE_PATH="/tmp/sbom-${arch}.json"
+            arch_imageanddigest="${imagewithouttag}@${arch_sha}"
 
             # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
             mkdir -p /tmp/auth && select-oci-auth "${arch_imageanddigest}" >/tmp/auth/config.json
             export DOCKER_CONFIG=/tmp/auth
 
             # Get base images from SBOM
-            cosign download sbom $arch_imageanddigest > ${SBOM_FILE_PATH}
-            if [ $? -ne 0 ]; then
+            if ! cosign download sbom "$arch_imageanddigest" > "${SBOM_FILE_PATH}"; then
               echo "Unable to download sbom for arch $arch."
               continue
             fi
@@ -150,7 +150,7 @@ spec:
           # Get images from the parameter
           for IMAGE_WITH_TAG in $(echo -n "$BASE_IMAGES_DIGESTS" | sed 's/\\n/\'$'\n''/g' );
           do
-            echo $IMAGE_WITH_TAG | cut -d ":" -f1 >> ${IMAGES_TO_BE_PROCESSED_PATH}
+            echo "$IMAGE_WITH_TAG" | cut -d ":" -f1 >> "${IMAGES_TO_BE_PROCESSED_PATH}"
           done
         fi
 
@@ -163,30 +163,30 @@ spec:
 
         for BASE_IMAGE in ${BASE_IMAGES};
         do
-          IFS=:'/' read -r IMAGE_REGISTRY IMAGE_REPOSITORY<<< $BASE_IMAGE
+          IFS=:'/' read -r IMAGE_REGISTRY IMAGE_REPOSITORY<<< "$BASE_IMAGE"
 
           # Red Hat Catalog hack: registry.redhat.io must be queried as registry.access.redhat.com in Red Hat catalog
           IMAGE_REGISTRY_CATALOG=$(echo "${IMAGE_REGISTRY}" | sed 's/^registry.redhat.io$/registry.access.redhat.com/')
 
-          export IMAGE_REPO_PATH=/tmp/${IMAGE_REPOSITORY}
-          mkdir -p ${IMAGE_REPO_PATH}
+          export IMAGE_REPO_PATH="/tmp/${IMAGE_REPOSITORY}"
+          mkdir -p "${IMAGE_REPO_PATH}"
           echo "Querying Red Hat Catalog for $BASE_IMAGE."
-          http_code=$(curl -s -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY_CATALOG}/repository/${IMAGE_REPOSITORY}")
+          http_code=$(curl -s -o "${IMAGE_REPO_PATH}/repository_data.json" -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY_CATALOG}/repository/${IMAGE_REPOSITORY}")
 
           if [ "$http_code" == "200" ];
           then
             echo "Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace."
-            /usr/bin/conftest test --no-fail ${IMAGE_REPO_PATH}/repository_data.json \
-            --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \
-            --output=json | tee ${IMAGE_REPO_PATH}/deprecated_image_check_output.json
+            /usr/bin/conftest test --no-fail "${IMAGE_REPO_PATH}/repository_data.json" \
+            --policy "$POLICY_DIR" --namespace "$POLICY_NAMESPACE" \
+            --output=json | tee "${IMAGE_REPO_PATH}/deprecated_image_check_output.json"
 
-            failures_num=$(jq -r '.[].failures|length' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)
+            failures_num=$(jq -r '.[].failures|length' "${IMAGE_REPO_PATH}/deprecated_image_check_output.json")
             if [[ "${failures_num}" -gt 0 ]]; then
               echo "[FAILURE] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} has been deprecated"
             fi
             failure_counter=$((failure_counter+failures_num))
 
-            successes_num=$(jq -r '.[].successes' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)
+            successes_num=$(jq -r '.[].successes' "${IMAGE_REPO_PATH}/deprecated_image_check_output.json")
             if [[ "${successes_num}" -gt 0 ]]; then
               echo "[SUCCESS] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} is valid"
             fi
@@ -223,9 +223,9 @@ spec:
             -r "${RES}" -n "$POLICY_NAMESPACE" \
             -s "${success_counter}" -f "${failure_counter}" -w "${warnings_counter}" -t "$note")
         fi
-        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
 
-        echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee $(results.IMAGES_PROCESSED.path)
+        echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee "$(results.IMAGES_PROCESSED.path)"
       volumeMounts:
       - name: trusted-ca
         mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt


### PR DESCRIPTION
- SC1091: Added `# shellcheck disable=SC1091` with explanation that `/utils.sh` is only available at container runtime
- SC2086: Quoted variables to prevent word splitting
- SC2116: Removed `$(echo ...)` wrappers
- SC2181: Replaced `cmd; if [ $? -ne 0 ]` with `if ! cmd; then`
- SC2046: Quoted `$(results.*.path)` Tekton substitutions
- SC2002: Replaced `cat file | tee` with `tee < file`
- SC2128: Fixed array access without index `(${args} -> ${#args[@]})`

Assisted-by: Claude Code (claude-opus-4-6)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
