### PR TITLE
feat(STONEINTG-1642): add skills for repo-specific task workflows

### DIFF
--- a/.claude/skills/ci-cd-quirks
+++ b/.claude/skills/ci-cd-quirks
@@ -1,0 +1,1 @@
+../../skills/ci-cd-quirks

--- a/.claude/skills/debugging-task-failures
+++ b/.claude/skills/debugging-task-failures
@@ -1,0 +1,1 @@
+../../skills/debugging-task-failures

--- a/.claude/skills/pr-definition-of-done
+++ b/.claude/skills/pr-definition-of-done
@@ -1,0 +1,1 @@
+../../skills/pr-definition-of-done

--- a/.claude/skills/task-generator-usage
+++ b/.claude/skills/task-generator-usage
@@ -1,0 +1,1 @@
+../../skills/task-generator-usage

--- a/.claude/skills/task-versioning-and-migration
+++ b/.claude/skills/task-versioning-and-migration
@@ -1,0 +1,1 @@
+../../skills/task-versioning-and-migration

--- a/.claude/skills/testing-tasks
+++ b/.claude/skills/testing-tasks
@@ -1,0 +1,1 @@
+../../skills/testing-tasks

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -1,0 +1,39 @@
+# Konflux Test Tasks AI Skills
+
+Repository-specific AI skills for the konflux-test-tasks Tekton task catalog. These skills are tool-agnostic and can be used with any AI agent (Claude Code, Codex, Goose, etc.) via symlinks to the agent's skill directory.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| [task-versioning-and-migration](task-versioning-and-migration/SKILL.md) | Version bumps, migration scripts, CHANGELOG.md, and the pmt modify workflow |
+| [testing-tasks](testing-tasks/SKILL.md) | Kind cluster tests, Tekton integration tests, ShellSpec unit tests, and test debugging |
+| [pr-definition-of-done](pr-definition-of-done/SKILL.md) | Pre-push checklist: all 14+ CI checks, commit conventions, generated files |
+| [ci-cd-quirks](ci-cd-quirks/SKILL.md) | Non-obvious CI behavior: templated files, bundle tagging, Checkton, migration validation |
+| [task-generator-usage](task-generator-usage/SKILL.md) | Go-based generators for remote and trusted-artifact task variants |
+| [debugging-task-failures](debugging-task-failures/SKILL.md) | Task result formats, scan output schemas, runner images, common failures |
+
+## Setup for Claude Code
+
+Skills are symlinked from `.claude/skills/` for automatic discovery:
+
+```
+.claude/skills/task-versioning-and-migration -> ../../skills/task-versioning-and-migration
+.claude/skills/testing-tasks -> ../../skills/testing-tasks
+.claude/skills/pr-definition-of-done -> ../../skills/pr-definition-of-done
+.claude/skills/ci-cd-quirks -> ../../skills/ci-cd-quirks
+.claude/skills/task-generator-usage -> ../../skills/task-generator-usage
+.claude/skills/debugging-task-failures -> ../../skills/debugging-task-failures
+```
+
+## Setup for Other Agents
+
+Create symlinks from your agent's skill directory to `skills/`:
+
+```bash
+# Example for Codex
+mkdir -p .agents/skills
+ln -s ../../skills/task-versioning-and-migration .agents/skills/
+ln -s ../../skills/testing-tasks .agents/skills/
+# ... etc
+```

--- a/skills/ci-cd-quirks/SKILL.md
+++ b/skills/ci-cd-quirks/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: ci-cd-quirks
+description: Use when CI behaves unexpectedly, when you need to understand how Tekton bundles are built, or when understanding non-obvious behavior with templated workflows, Checkton, migration validation, kustomize checks, or trusted artifacts generation.
+---
+
+# CI/CD Quirks and Gotchas
+
+## Overview
+
+This repo's CI is heterogeneous: templated GitHub Actions workflows, task-specific Tekton build pipelines with CEL-based path triggers, Conforma policies, and shared CI update automation. Several behaviors are non-obvious.
+
+## When to Use
+
+- CI failed and you don't understand why
+- Need to understand how task bundles are built and tagged
+- Checkton or task-lint is blocking your PR
+- Understanding what's templated vs what's local
+- Migration validation mysteriously passes/fails
+
+## Templated vs Local Files
+
+Files with `<TEMPLATED FILE!>` header come from [task-repo-shared-ci](https://github.com/konflux-ci/task-repo-shared-ci).
+
+**Templated (do NOT edit):**
+
+- Most of `hack/` directory
+- Most `.github/workflows/` (except task-specific ones)
+- `.github/scripts/`
+
+**Local (edit freely):**
+
+- All `task/` YAML files and directories
+- `.tekton/` build pipelines
+- `.tekton/integration/` test definitions
+- `policies/` Conforma policies
+- `CODEOWNERS`, `renovate.json`, `README.md`
+
+**Update template:**
+
+```bash
+cruft update --skip-apply-ask --allow-untracked-files
+```
+
+Automated weekly via `update-shared-ci.yaml` workflow.
+
+## Tekton Bundle Build System
+
+### How task bundles are built
+
+Each task version gets its own Tekton PipelineRun definition: `.tekton/<task>-<ver>-pull-request.yaml` and `.tekton/<task>-<ver>-push.yaml`
+
+These are templated via Pipelines-as-Code and triggered by CEL expressions matching path changes.
+
+**Example:** `clair-scan-v03-pull-request.yaml` triggers on changes to `task/clair-scan/***`
+
+**Build output:**
+
+- Bundle image: `quay.io/redhat-user-workloads/rhtap-integration-tenant/<task>:<tag>`
+- Tag on PR: `on-pr-<git-revision>`
+- Tag on push: `<git-revision>`
+- PR images expire after 5 days; max 3 kept
+
+### Tag scheme (build-and-push.sh)
+
+- **Floating tag:** `<major.minor>` — always points to latest bundle
+- **Fixed tag:** `<task>-<identifier>` — immutable snapshot
+  - Identifier for normal tasks: git commit hash
+  - Identifier for kustomized tasks: content hash (reproducible)
+
+Both tags point to same image; use fixed tag for stability.
+
+## Checkton (ShellCheck on YAML)
+
+Checkton lints shell scripts embedded in YAML files.
+
+**Workflow:** `.github/workflows/checkton.yaml`
+
+**What it checks:** ShellCheck rules on every `script:` block in Tekton files
+
+**Behavior:**
+
+- Differential mode: runs on full git history (commits you changed)
+- Excludes: `task-generator/` directory
+- Run locally: `hack/checkton-local.sh` (requires podman/docker)
+
+**Inline directives work:**
+
+```yaml
+script: |
+  # shellcheck disable=SC2016  # Single quotes with $ are fine
+  echo "$(params.my-param)"
+```
+
+**Common failures:**
+
+- SC2016: Single quotes with `$` (use double quotes for interpolation)
+- SC1091: Can't follow source (ignore if source is injected)
+- SC2086: Unquoted variable (quote: `"$var"` not `$var`)
+
+## Task Lint (Security Rule)
+
+**Workflow:** `.github/workflows/task-lint.yaml`
+
+**What it checks:** `$(params.*)` used directly in `.spec.steps[].script` blocks
+
+**Why it fails:** Raw parameter substitution = code injection risk. Tekton performs text replacement before script execution.
+
+**Correct pattern:**
+
+```yaml
+spec:
+  steps:
+    - name: my-step
+      env:
+        - name: IMAGE_URL
+          value: "$(params.image-url)"
+      script: |
+        echo "$IMAGE_URL"  # NOT $(params.image-url)
+```
+
+## Migration Validation Quirks
+
+**Workflow:** `.github/workflows/check-task-migration.yaml`
+
+**Requirements:**
+
+- kind cluster running locally (if testing)
+- Tekton Pipelines installed (`kubectl apply -f release.yaml`)
+- `pmt` (pipeline-migration-tool) in PATH
+- Konflux standard pipelines accessible (downloaded from ConfigMap)
+
+**Validation steps:**
+
+1. Finds all `migrations/*.sh` files
+2. Downloads real Konflux standard pipelines from ConfigMap
+3. Applies each migration to each pipeline
+4. Diffs before/after
+5. Fails if migration changes nothing (no-op)
+6. Fails if `yq -i` used instead of `pmt modify`
+
+**Local testing:**
+
+```bash
+# Prerequisites
+kind create cluster
+kubectl apply -f https://github.com/tektoncd/pipeline/releases/latest/download/release.yaml
+go install github.com/konflux-ci/pipeline-migration-tool/cmd/pmt@latest
+
+# Validate
+IN_CLUSTER=1 bash ./hack/validate-migration.sh
+```
+
+**Gotchas:**
+
+- Migration must change at least one pipeline (no-op = failure)
+- Cannot delete or modify existing migration files (only add new ones)
+- One migration per task per PR
+- OCI-TA variants need separate migrations
+
+## Kustomize Build Check
+
+**Workflow:** `.github/workflows/check-kustomize-build.yaml`
+
+**What it checks:** Generated manifest files are up to date
+
+**Command:** `hack/build-manifests.sh` (uses `oc kustomize` binary)
+
+**Requirement:** OpenShift CLI (`oc`) installed
+
+**Scope:** Only rebuilds tasks with `kustomization.yaml` that reference external resources
+
+**Gotcha:** Kustomize auto-adds comment `# <auto-generated>` at top of output — don't remove it
+
+## Trusted Artifacts Check
+
+**Workflow:** `.github/workflows/check-ta.yaml`
+
+**Two checks:**
+
+1. **Variant generation:** `hack/generate-ta-tasks.sh` — generates from `recipe.yaml`
+2. **Missing variant detection:** `hack/missing-ta-tasks.sh` — flags workspace-using tasks without `-oci-ta` variant
+
+**Ignore file (optional):** `.github/.ta-ignore.yaml` or `.ta-ignore.yaml`
+
+This file does **not** exist in this repo by default. Create it only when you need to exclude specific tasks or workspace names from the TA check.
+
+```yaml
+paths:
+  - task/some-task/*     # Don't require TA variant for this task
+workspaces:
+  - netrc-auth           # Workspace names that don't share data
+  - git-auth
+```
+
+**Gotcha:** Only tasks with workspaces that share data between tasks need TA variants. Read-only or local workspaces don't.
+
+## Conforma Policies
+
+**Location:** `policies/`
+
+**Files:**
+
+- `all-tasks.yaml` — Policies applied to all task bundles
+- `build-tasks.yaml` — Build-specific policies
+- `step-actions.yaml` — Step action policies
+
+**Policy enforcement:** During bundle image build via Enterprise Contract
+
+## Generation Pipeline Order
+
+When regenerating multiple types of variants, run in this order:
+
+```bash
+hack/build-manifests.sh         # Kustomize first
+hack/generate-ta-tasks.sh       # TA variants second
+hack/generate-buildah-remote.sh # Remote variants last (if exists)
+```
+
+Or just: `hack/generate-everything.sh`
+
+**Why order matters:** Later generators may depend on outputs of earlier ones.
+
+## Common Surprises
+
+| Surprise | Explanation |
+|----------|-------------|
+| PR only triggers some Tekton pipelines | CEL expression scopes trigger to specific task paths. Check `.tekton/<task>-pull-request.yaml`. |
+| "Stale manifests" even though I changed the right file | Kustomized task requires `hack/build-manifests.sh`. Re-run if you touched `kustomization.yaml` or `patch.yaml`. |
+| Checkton flags inline script I didn't change | Differential mode uses full git history. Run locally: `hack/checkton-local.sh` to verify. |
+| Migration check passes locally but fails in CI | Local version may not have Tekton installed. CI has it. Use `IN_CLUSTER=1 bash ./hack/validate-migration.sh` locally. |
+| `generate-everything.sh` changed files I didn't modify | Generators are deterministic but may update manifests when templates change. Commit generated files. |
+| Can't find `generate-buildah-remote.sh` | Verify it exists: `ls hack/generate-buildah-remote.sh`. May be added/removed by cruft updates. |
+
+## Non-Obvious Gotchas
+
+- **Bundle expiry:** PR images expire after 5 days. Don't rely on old PR bundles.
+- **Migration idempotency:** `pmt` commands are idempotent, but your script might not be. Test running migration twice.
+- **CODEOWNERS + renovate.json:** Must stay in sync. `hack/check-task-owners.sh` validates this.
+- **Kustomize overlay paths:** Relative paths in kustomization.yaml must point to correct base. Check paths match directory structure.

--- a/skills/debugging-task-failures/SKILL.md
+++ b/skills/debugging-task-failures/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: debugging-task-failures
+description: Use when a scan task fails in a pipeline, when task results have unexpected values, when understanding scan output formats, or when debugging bundle build failures.
+---
+
+# Debugging Task Failures
+
+## Overview
+
+Debugging Tekton task failures in pipelines requires understanding task result formats, runner images, and common failure patterns. These scanning tasks (clair-scan, clamav-scan, deprecated-image-check, roxctl-scan, tpa-scan) share common patterns and error modes.
+
+## When to Use
+
+- A scan task fails in a Konflux pipeline
+- Task results have unexpected structure or values
+- Understanding what each result field means
+- Debugging bundle build failures
+- Reading scan reports attached to images as OCI artifacts
+
+## Task Result Formats
+
+All scanning tasks must produce standardized result formats.
+
+### TEST_OUTPUT (all tasks)
+
+JSON object with scan result status:
+
+```json
+{
+  "result": "SUCCESS|WARNING|ERROR|SKIPPED",
+  "note": "Human-readable description of result",
+  "timestamp": "ISO-8601 timestamp (e.g., 2025-05-20T14:30:00Z)"
+}
+```
+
+**Result values:**
+
+- `SUCCESS` — scan passed, no issues found
+- `WARNING` — scan completed with non-critical issues
+- `ERROR` — scan failed or found critical issues
+- `SKIPPED` — scan was skipped (image not relevant, etc.)
+
+### SCAN_OUTPUT (vulnerability tasks only)
+
+JSON object with vulnerability counts by severity:
+
+```json
+{
+  "vulnerabilities": {
+    "critical": 0,
+    "high": 2,
+    "medium": 5,
+    "low": 12,
+    "unknown": 1
+  },
+  "unpatched_vulnerabilities": {
+    "critical": 0,
+    "high": 0,
+    "medium": 1,
+    "low": 5,
+    "unknown": 0
+  }
+}
+```
+
+- `vulnerabilities` — Total count by severity from scan database
+- `unpatched_vulnerabilities` — Vulnerabilities without available patches
+
+### IMAGES_PROCESSED
+
+JSON object mapping image pull specifications to their digests:
+
+```json
+{
+  "image": {
+    "pullspec": "quay.io/org/image:tag",
+    "digests": ["sha256:abc123...", "sha256:def456..."]
+  }
+}
+```
+
+Multiple digests if image built for multiple architectures.
+
+### REPORTS
+
+JSON object mapping image digests to OCI artifact report digests:
+
+```json
+{
+  "sha256:abc123...": {
+    "scan_report": "sha256:report-digest-1...",
+    "compliance_report": "sha256:report-digest-2..."
+  }
+}
+```
+
+Reports are stored as OCI artifacts in the image registry.
+
+## Common Task Step Failures
+
+### clair-scan (Vulnerability Scanning)
+
+| Step | Failure | Cause | Fix |
+|------|---------|-------|-----|
+| `get-image-manifests` | "unauthorized" | Missing docker auth or expired token | Check secret/credentials are mounted |
+| `get-image-manifests` | "not found" | Image does not exist in registry | Verify image pull spec is correct |
+| `get-vulnerabilities` | OOM killed | Image has too many layers; too much memory | Increase `computeResources.limits.memory` |
+| `oci-attach-report` | "failed to push" | Registry auth issue or storage quota exceeded | Check registry credentials and quota |
+| `conftest-vulnerabilities` | Policy violation | Vulnerability severity exceeds threshold | Review Conforma policies in `policies/` |
+
+### clamav-scan (Antivirus Scanning)
+
+Similar to clair-scan but uses ClamAV malware database instead of vulnerability DB.
+
+| Step | Failure | Cause | Fix |
+|------|---------|-------|-----|
+| `clamscan-image` | "database outdated" | ClamAV DB not current | Update clamav-db image in task |
+| `clamscan-image` | Timeout | Large image with many files | Increase timeout or exclude paths |
+
+### deprecated-image-check (Base Image Deprecation)
+
+| Step | Failure | Cause | Fix |
+|------|---------|-------|-----|
+| `get-image-data` | "service unavailable" | Pyxis API down (Red Hat's image metadata service) | Retry later; not a task issue |
+| `conftest-deprecated` | Policy failure | Base image marked as deprecated | Update to newer base image |
+
+### roxctl-scan (Red Hat ACS)
+
+| Step | Failure | Cause | Fix |
+|------|---------|-------|-----|
+| `roxctl-image-scan` | "connection refused" | ROX_CENTRAL_ADDR unreachable | Verify ACS cluster URL and network access |
+| `roxctl-image-scan` | "authentication failed" | ROX_API_TOKEN invalid or expired | Regenerate API token in ACS |
+
+### tpa-scan (Trusted Profile Analyzer)
+
+| Step | Failure | Cause | Fix |
+|------|---------|-------|-----|
+| `tpa-scan` | "timeout" | TPA service slow or unresponsive | Retry; may be service issue |
+
+## Runner Images
+
+All scanning tasks use utility images from Konflux:
+
+| Image | Purpose | Source |
+|-------|---------|--------|
+| `quay.io/konflux-ci/konflux-test` | General utility functions, conftest policy execution | github.com/konflux-ci/konflux-test |
+| `quay.io/konflux-ci/task-runner` | OCI artifact attachment via oras | github.com/konflux-ci/task-runner |
+| `quay.io/konflux-ci/clair-in-ci:latest` | Clair vulnerability database | github.com/konflux-ci/clair-in-ci-db |
+| `quay.io/konflux-ci/clamav-db:latest` | ClamAV antivirus database | github.com/konflux-ci/konflux-clamav |
+
+**Pinning:** Most tasks use floating `latest` tags. For reproducibility, pin to specific digest: `image@sha256:...`
+
+## Environment Variable Pattern
+
+Never use Tekton parameters directly in scripts. Always pass through env vars first.
+
+**WRONG (security risk):**
+
+```yaml
+spec:
+  steps:
+    - name: scan
+      script: |
+        scan-tool "$(params.image-url)"  # Code injection vulnerability
+```
+
+**CORRECT:**
+
+```yaml
+spec:
+  steps:
+    - name: scan
+      env:
+        - name: IMAGE_URL
+          value: "$(params.image-url)"
+      script: |
+        scan-tool "$IMAGE_URL"  # Safe
+```
+
+## Retry Logic
+
+Most scan tasks use `RETRY_COUNT` (default: 5) for transient failures (timeouts, rate limits).
+
+Set via `stepTemplate` env variable:
+
+```yaml
+spec:
+  stepTemplate:
+    env:
+      - name: RETRY_COUNT
+        value: "3"
+```
+
+## Debugging Bundle Builds
+
+Each task version has build pipelines in `.tekton/`:
+
+**Pull request:** `.tekton/<task>-<ver>-pull-request.yaml`  
+**Push:** `.tekton/<task>-<ver>-push.yaml`
+
+**Debug steps:**
+
+1. Find the PipelineRun in Pipelines-as-Code logs
+2. Check step status and logs in Konflux UI
+3. Look for:
+   - Build failures (container build failed)
+   - Security scan failures (clair, clamav, SAST)
+   - Signing failures (image signature issues)
+4. Common issues:
+   - Multistage Dockerfile issue (final stage too large)
+   - Base image vulnerabilities
+   - Embedded secrets (catch-all scan)
+
+## Attachment vs Embedded Results
+
+- **Embedded results:** Part of Tekton task result (4KB limit)
+- **Attached results:** OCI artifacts stored separately, linked via digest
+
+Large scan reports are attached via `oras push` in `oci-attach-report` step.
+
+**Access attached reports:**
+
+```bash
+oras pull <image>@<digest> --output /tmp/
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Result JSON malformed | Validate with `jq` before returning result. Use `jq -r @json` to escape. |
+| Result too large (>4KB) | Use OCI artifact attachment for large output. Summarize in embedded result. |
+| Image pull fails silently | Check docker/podman auth is configured. Verify image exists. |
+| Task times out | Check `timeout` parameter in PipelineRun. Increase if legitimate operation is slow. |
+| OCI artifact attach fails | Verify registry credentials. Check storage quota. Ensure oras binary is in image. |
+| Conftest policy fails unexpectedly | Review policies in `policies/`. Add `--debug` flag to conftest for verbose output. |
+| CA certificate validation fails | Mount CA trust ConfigMap via `ca-trust-config-map-name` parameter. |

--- a/skills/pr-definition-of-done/SKILL.md
+++ b/skills/pr-definition-of-done/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: pr-definition-of-done
+description: Use before pushing a PR for review, when CI checks fail, or when reviewing someone else's PR. Pre-push checklist covering all CI requirements, commit conventions, and documentation for task catalog PRs.
+---
+
+# PR Definition of Done
+
+## Overview
+
+14+ GitHub Actions workflows run on every PR. This checklist ensures you pass all CI checks before pushing, reducing round-trip time and review cycles. Each section maps to a CI workflow.
+
+## When to Use
+
+- Before pushing a PR for review
+- When CI check fails and you need to know which one
+- When reviewing someone else's PR
+- To understand what CI validates
+
+## Pre-Push Checklist
+
+### Commits
+
+- [ ] Conventional commit format: `type(STONEINTG-XXXX): description`
+- [ ] Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
+- [ ] Signed-off: `git commit -s` (DCO signature)
+- [ ] Title < 72 characters
+- [ ] AI-assisted: add trailer `Assisted-by: <tool-name>` if used
+
+### Task YAML Changes
+
+- [ ] Version label bumped if change should be released: `app.kubernetes.io/version: "x.y[.z]"`
+- [ ] CHANGELOG.md updated (or "Unreleased" section if not releasing)
+- [ ] Never use `$(params.*)` directly in scripts — use env variables instead
+- [ ] All bash scripts start with `#!/usr/bin/env bash` and `set -euo pipefail`
+- [ ] No trailing newlines at EOF; last line ends with newline
+
+### Generated Files (run when needed)
+
+- [ ] Kustomize manifests updated: `hack/build-manifests.sh` (for -min variants)
+- [ ] README auto-generated: `hack/generate-readme.sh` (if task interface changed)
+- [ ] Or run all generators: `hack/generate-everything.sh`
+
+### Migrations (if version bumped)
+
+- [ ] Migration script created at `task/<name>/migrations/<version>.sh`
+- [ ] Uses `pmt modify`, NOT `yq -i`
+- [ ] Passes shellcheck: `shellcheck task/<name>/migrations/<version>.sh`
+- [ ] If task has `-oci-ta` variant, create migration there too
+- [ ] CHANGELOG.md updated with user-facing migration notes
+
+### Code Formatting
+
+- [ ] No unrelated whitespace changes
+- [ ] No tabs on empty lines
+- [ ] One newline at end of file only
+- [ ] YAML indentation 2 spaces (consistent with existing files)
+
+### Security
+
+- [ ] No secrets, API keys, or credentials committed
+- [ ] No sensitive info in commit messages or PR description
+- [ ] Container image references are trusted (konflux-ci, quay.io/redhat-user-workloads, etc.)
+
+## CI Checks Matrix
+
+| Workflow | Triggered By | What Fails It | Repo File |
+|----------|-------------|--------------|-----------|
+| **YAML Lint** | Any `.yaml`, `.yml` file change | YAML syntax errors, indentation | `.github/workflows/yaml-lint.yaml` |
+| **Checkton** | Task YAML changes | ShellCheck violations in embedded scripts | `.github/workflows/checkton.yaml` |
+| **Task Lint** | Task YAML changes | `$(params.*)` used directly in script blocks | `.github/workflows/task-lint.yaml` |
+| **Versioning** | Task YAML changes | Missing `app.kubernetes.io/version` label, missing CHANGELOG.md | `.github/workflows/versioning.yaml` |
+| **Kustomize Build** | `kustomization.yaml`, `patch.yaml` changes | Regenerated manifest files stale | `.github/workflows/check-kustomize-build.yaml` |
+| **Task Migrations** | Migration files added/modified | Invalid migration script, failed `pmt modify` | `.github/workflows/check-task-migration.yaml` |
+| **Check READMEs** | README files, task structure changes | README out of date or missing | `.github/workflows/check-readmes.yaml` |
+| **Check Task YAMLs** | Task YAML changes | Invalid Tekton task definition (kubectl dry-run) | `.github/workflows/check-task-yamls.yaml` |
+| **Check TA Variants** | Task changes | Missing or stale trusted-artifacts variants | `.github/workflows/check-ta.yaml` |
+| **Check Task Owners** | CODEOWNERS changes | Mismatch between CODEOWNERS and renovate.json | `.github/workflows/check-task-owners.yaml` |
+| **Go CI** | `task-generator/*/` changes | golangci-lint, go test, go mod tidy failures | `.github/workflows/go-ci.yaml` |
+| **Run Task Tests** | Task `tests/` directory changes | Kind cluster test pipeline failures | `.github/workflows/run-task-tests.yaml` |
+| **AgentReady** | Any file change | Code quality and AI-readiness assessment | `.github/workflows/agentready.yaml` |
+
+## Templated Files Warning
+
+Files marked with `<TEMPLATED FILE!>` comment come from [task-repo-shared-ci](https://github.com/konflux-ci/task-repo-shared-ci).
+
+**Do NOT edit these files directly.** Instead, send PR upstream to the template repo or use:
+
+```bash
+cruft update --skip-apply-ask --allow-untracked-files
+```
+
+Check for `<TEMPLATED FILE!>` in:
+
+- Most of `hack/`
+- Most of `.github/workflows/`
+- `.github/scripts/`
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Edited a TEMPLATED FILE | Send PR to task-repo-shared-ci instead; or run `cruft update` |
+| Kustomize manifests stale | `hack/build-manifests.sh` after changing `kustomization.yaml` or `patch.yaml` |
+| TA variant out of date | `hack/generate-ta-tasks.sh` |
+| `$(params.*)` in script | Create env var in task spec: `env: - name: MY_VAR value: "$(params.my-param)"` then use `$MY_VAR` |
+| Missing CODEOWNERS entry | Add task to CODEOWNERS; run `hack/check-task-owners.sh -f` |
+| Checkton fails locally but not in CI | CI uses full git diff history. Run locally: `hack/checkton-local.sh` |
+| Versioning warning treated as error | Versioning warnings don't block merge. But best practice: always update version + CHANGELOG together. |

--- a/skills/task-generator-usage/SKILL.md
+++ b/skills/task-generator-usage/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: task-generator-usage
+description: Use when creating task variants (remote, trusted-artifacts), working with recipe.yaml files, or when the check-ta CI workflow fails. Covers both Go generators, the recipe format, and the generation pipeline.
+---
+
+# Task Generator Usage
+
+## Overview
+
+Two Go programs in `task-generator/` generate task variants: **remote** for multi-platform builds, and **trusted-artifacts** for OCI-based artifact sharing. Trusted-artifacts is enforced by CI; remote is optional.
+
+## When to Use
+
+- Creating a trusted-artifacts (-oci-ta) variant of a task
+- Creating a remote variant of a task
+- "Check Trusted Artifact variants" CI fails
+- Modifying `recipe.yaml` configuration
+- Understanding the generation pipeline and order
+
+## Generators
+
+| Generator | Path | Purpose | Use When |
+|-----------|------|---------|----------|
+| Trusted Artifacts | `task-generator/trusted-artifacts/` | Generates OCI-TA variants from `recipe.yaml` | Task uses workspaces to share data |
+| Remote | `task-generator/remote/` | Generates multi-platform variants | Need multiple architectures (x86, arm64) |
+
+## Trusted Artifacts Generator
+
+### When a task needs a TA variant
+
+Any task that uses workspaces to share data with other tasks needs a TA variant.
+
+**The CI check** `hack/missing-ta-tasks.sh` in `.github/workflows/check-ta.yaml` enforces this automatically.
+
+**Exception:** Workspace is listed in `.ta-ignore.yaml` (e.g., `netrc-auth` for read-only creds)
+
+### Creating a TA variant
+
+**Step 1:** Create directory mirroring base task structure
+
+```
+task/<task-name>-oci-ta/
+```
+
+**Step 2:** Create `recipe.yaml` (TA generator configuration)
+
+```yaml
+---
+base: ../../<task-name>/<task-name>.yaml
+add:
+  - create-source
+  - use-source
+removeWorkspaces:
+  - source  # Remove workspaces no longer needed in TA variant
+replacements:
+  - old: image: quay.io/external/image
+    new: image: quay.io/internal/image
+addParams:
+  - name: ca-trust-config-map
+    description: ConfigMap with CA certs
+    type: string
+addResult:
+  - name: ta-report
+    type: string
+```
+
+**Step 3:** Generate the TA variant YAML
+
+```bash
+hack/generate-ta-tasks.sh
+```
+
+Output: `task/<task-name>-oci-ta/<task-name>-oci-ta.yaml` (auto-generated)
+
+**Step 4:** Commit both `recipe.yaml` and generated YAML
+
+```bash
+git add task/<task-name>-oci-ta/
+git commit -m "feat: add trusted-artifacts variant of <task-name>"
+```
+
+### recipe.yaml Configuration
+
+**Basic options:**
+
+| Option | Purpose | Example |
+|--------|---------|---------|
+| `base` | Path to base task YAML (relative to recipe.yaml) | `../../clair-scan/clair-scan.yaml` |
+| `add` | Transformations to apply | `create-source`, `use-source`, `copy-from-source` |
+| `removeWorkspaces` | Workspace names to remove | `source`, `temp` |
+| `removeSteps` | Step names to remove from task | `setup`, `cleanup` |
+| `replacements` | String replacements in YAML | `old:` / `new:` pairs |
+| `regexReplacements` | Regex-based replacements | `regex:` / `replacement:` pairs |
+| `addParams` | Parameters to add | `name:`, `type:`, `description:` |
+| `addResults` | Results to add | `name:`, `type:` |
+| `addEnvironment` | Environment variables | `name:`, `value:` |
+
+**Detailed format:**
+
+```yaml
+base: ../../task-name/task-name.yaml
+
+add:
+  - create-source    # Creates source archive from input workspace
+  - use-source       # Uses source archive instead of workspace
+  - copy-from-source # Copies specific files from archive
+
+removeWorkspaces:
+  - workspace-name
+
+removeSteps:
+  - step-name
+
+replacements:
+  - old: "old-string"
+    new: "new-string"
+
+regexReplacements:
+  - regex: "pattern.*"
+    replacement: "new-value"
+
+addParams:
+  - name: param-name
+    type: string
+    default: "default-value"
+    description: "Description of parameter"
+
+addResults:
+  - name: result-name
+    type: string
+
+addEnvironment:
+  - name: ENV_VAR
+    value: "value"
+```
+
+### Kustomized TA Variants
+
+For kustomized tasks (like `-min` variants), the TA variant can also be kustomized.
+
+**Structure:**
+
+```
+task/<task-name>-oci-ta/
+├── CHANGELOG.md
+├── recipe.yaml
+└── kustomization.yaml     # References base TA variant
+```
+
+**Example kustomization.yaml:**
+
+```yaml
+bases:
+  - ../../<task-name>-oci-ta
+
+patchesStrategicMerge:
+  - patch.yaml
+```
+
+### Documentation
+
+For complete `recipe.yaml` format and examples, see the upstream repository:
+
+https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts
+
+## Generation Pipeline Order
+
+When regenerating multiple types of variants, run in this exact order:
+
+```bash
+hack/build-manifests.sh         # Step 1: Kustomize manifests
+hack/generate-ta-tasks.sh       # Step 2: Trusted-artifacts variants
+hack/generate-buildah-remote.sh # Step 3: Remote variants
+```
+
+Or run all at once:
+
+```bash
+hack/generate-everything.sh
+```
+
+**Why order matters:** Later generators depend on outputs of earlier ones.
+
+## Testing Generators
+
+Both generators have unit tests:
+
+```bash
+cd task-generator/trusted-artifacts
+go test ./...
+
+cd ../remote
+go test ./...
+```
+
+**Golden tests:** Reference test outputs in `task-generator/trusted-artifacts/golden/`
+
+These ensure generated YAML is reproducible and matches expected format.
+
+## Ignore File for Missing TA Variants
+
+If a workspace-using task should NOT have a TA variant, add it to `.ta-ignore.yaml`:
+
+**Path:** `.github/.ta-ignore.yaml` or `.ta-ignore.yaml` (highest precedence first)
+
+```yaml
+# Task paths (glob patterns) to ignore
+paths:
+  - task/some-task/*
+  - task/another-task/*/*
+
+# Workspace names that don't require TA variants
+# (local or read-only workspaces, not shared between tasks)
+workspaces:
+  - netrc-auth
+  - git-auth
+  - ca-trust
+```
+
+## CI Checks
+
+**Workflow:** `.github/workflows/check-ta.yaml`
+
+**Checks:**
+
+1. **Generation:** `hack/generate-ta-tasks.sh` succeeds
+2. **Completeness:** `hack/missing-ta-tasks.sh` finds no workspace-using tasks without TA variants
+3. **Up-to-date:** Generated YAML matches recipe.yaml (no manual edits)
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Generated YAML file not committed | Run `hack/generate-ta-tasks.sh`, commit output alongside `recipe.yaml` |
+| recipe.yaml path wrong | Use relative path from recipe.yaml to base task. Verify with `ls` from recipe.yaml location. |
+| Missing `-oci-ta` CHANGELOG.md | Create `task/<name>-oci-ta/CHANGELOG.md` with same format as base task |
+| Go mod tidy drift in generator | `cd task-generator/<dir> && go mod tidy && go mod vendor` |
+| Generator binary not in PATH | Install: `go install ./cmd/...` from task-generator directory |
+| Edited generated YAML by hand | Don't. Regenerate from recipe.yaml. Your edits will be lost on next run. |
+| Wrong base task path in recipe.yaml | Check path exists: `ls $(dirname recipe.yaml)/<base-path>` |

--- a/skills/task-versioning-and-migration/SKILL.md
+++ b/skills/task-versioning-and-migration/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: task-versioning-and-migration
+description: Use when creating a new task version, bumping version labels, writing migration scripts, or when versioning/migration CI checks fail. Covers version labels, CHANGELOG.md, migration scripts with pmt modify, and kustomized variant updates.
+---
+
+# Task Versioning and Migration
+
+## Overview
+
+Versioning in this repo involves coordinating the `app.kubernetes.io/version` label, `CHANGELOG.md`, and optional migration scripts in the `migrations/` directory. When a task interface changes or a critical bug is fixed, you create a new version and optionally a migration script to help users update their pipelines automatically.
+
+## When to Use
+
+- Creating a new major.minor or patch version of a task
+- Writing migration scripts for pipeline updates
+- "Versioning" or "Check task migrations" CI checks fail
+- Updating CHANGELOG.md for a task
+- Understanding the version bump + migration workflow
+
+## Quick Reference
+
+| Action | Command/File | Notes |
+|--------|--------------|-------|
+| Bump version | Edit `task/<name>/<name>.yaml`, update label `app.kubernetes.io/version` | Format: `x.y` or `x.y.z` |
+| Create migration | `mkdir -p task/<name>/migrations && touch task/<name>/migrations/<version>.sh` | Filename must match version label |
+| Create migration helper | `./hack/create-task-migration.sh -t <task-name>` | Generates template script |
+| Validate locally | `./hack/versioning.py check` | Checks version label + CHANGELOG |
+| Check migration | `bash ./hack/validate-migration.sh` | Requires kind + pmt installed |
+| Add CHANGELOG | `./hack/versioning.py new-changelog task/<name>/` | Creates or updates CHANGELOG.md |
+
+## Version Label Rules
+
+The `app.kubernetes.io/version` label in task YAML metadata controls versioning:
+
+```yaml
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.2"
+    # or
+    app.kubernetes.io/version: "0.2.1"
+```
+
+- Format: `x.y` or `x.y.z` (integers only, no strings like "v0.2")
+- Migration filename must match exactly: `migrations/0.2.sh` for version `0.2`
+- CI checks: versioning.yaml validates label format and CHANGELOG presence
+
+## Creating a Migration Script
+
+Migrations use `pmt modify` (NOT `yq -i`) to update Konflux standard pipelines.
+
+**File structure:**
+
+```
+task/<task-name>/
+├── <task-name>.yaml           # with updated app.kubernetes.io/version label
+└── migrations/
+    └── <version>.sh           # e.g., 0.2.sh
+```
+
+**Script template:**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+pipeline_file="$1"
+
+# pmt modify is idempotent - safe to run multiple times
+pmt modify -f "$pipeline_file" task <task-name> add-param my-new-param "default-value"
+```
+
+**Requirements:**
+
+- Single argument: `$1` = pipeline file path (Pipeline or PipelineRun)
+- Use `pmt modify` commands (NEVER `yq -i`)
+- Idempotent (safe to run multiple times)
+- Pass shellcheck without custom rules
+- Keep simple and focused
+
+**Testing the script locally:**
+
+```bash
+pmt modify -f /path/to/.tekton/component-a-pull.yaml task clair-scan add-param my-param "value"
+```
+
+## CHANGELOG.md Requirements
+
+Each task MUST have a `CHANGELOG.md` at `task/<name>/CHANGELOG.md`.
+
+**Format:** Follow [keepachangelog.com](https://keepachangelog.com) format
+
+**Example:**
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [0.2] - 2025-05-20
+
+### Added
+- New parameter: `my-new-param`
+
+### Changed
+- Updated base image from ubi8 to ubi9
+
+## [0.1] - 2025-04-15
+
+### Added
+- Initial release
+```
+
+**Rules:**
+
+- Required for all tasks (CI warns if missing)
+- Use "Unreleased" section for changes before release
+- Update when bumping version
+- CI requires both CHANGELOG update AND version bump together (warning only, not blocker)
+
+## Steps Required from User
+
+When bumping a task version and adding a migration, the user must do all of these steps — in order:
+
+1. Edit the task YAML: update `app.kubernetes.io/version` label to the new version (e.g. `0.2` → `0.3`)
+2. Create the migration script: `task/<name>/migrations/<version>.sh` using `pmt modify` commands
+3. If the task has an `-oci-ta` variant: create a matching migration in `task/<name>-oci-ta/migrations/<version>.sh`
+4. Update `task/<name>/CHANGELOG.md`: add an entry for the new version under the appropriate section
+5. If the task is kustomized (e.g. `-min` variant): run `hack/build-manifests.sh` to regenerate the variant YAML
+6. Verify the migration locally: `bash ./hack/validate-migration.sh` (requires kind + Tekton + pmt)
+7. Run shellcheck on the migration script: `shellcheck task/<name>/migrations/<version>.sh`
+
+Nothing is optional — CI enforces all of steps 1–4. Steps 5–7 prevent CI failures before push.
+
+## When to Create a New Version Directory
+
+**Note:** The repo supports both flat (`task/<name>/<name>.yaml`) and legacy versioned (`task/<name>/<ver>/<name>.yaml`) structures. The version is determined by the `app.kubernetes.io/version` label, NOT the directory.
+
+Create a new version when:
+
+1. Task interface changes (params renamed/added/removed, workspaces changed, results changed)
+2. Non-backward-compatible functionality changes
+3. Critical bug fix requiring updated implementation
+4. Adding new features users should opt into
+
+Include a migration script and updated CHANGELOG.md.
+
+## Kustomized Task Variants (-min tasks)
+
+Kustomized variants (like `clair-scan-min`) reference their base task via `kustomization.yaml`:
+
+```yaml
+# task/clair-scan-min/kustomization.yaml
+bases:
+  - ../../clair-scan
+
+patchesStrategicMerge:
+  - patch.yaml
+```
+
+**When base task bumps version:**
+
+1. Update base task version label
+2. Run `hack/build-manifests.sh` to regenerate kustomized variants
+3. Commit regenerated YAML files
+4. Optionally create migration for the -min variant too
+
+## OCI-TA Variant Migrations
+
+If a task has an `-oci-ta` variant, it MUST also get a migration script. The `validate-migration.sh` CI check enforces this automatically.
+
+Structure:
+
+```
+task/<task-name>/
+└── migrations/
+    └── 0.2.sh
+
+task/<task-name>-oci-ta/
+└── migrations/
+    └── 0.2.sh
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Migration filename doesn't match version label | Ensure `app.kubernetes.io/version` exactly matches `migrations/<ver>.sh` filename |
+| Used `yq -i` in migration | Replace with `pmt modify` commands. See pmt README for all subcommands. |
+| Forgot CHANGELOG.md | `./hack/versioning.py new-changelog task/<name>/` |
+| Modified an existing migration file | Not allowed. Create a new version instead. |
+| Base task bumped, -min variant stale | Run `hack/build-manifests.sh` after any kustomization changes |
+| Missing OCI-TA migration | Create migration in both base and `-oci-ta` directories |
+| Version label has "v" prefix | Remove: use `0.2`, not `v0.2` |

--- a/skills/testing-tasks/SKILL.md
+++ b/skills/testing-tasks/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: testing-tasks
+description: Use when writing tests for a Tekton task, running tests locally, debugging test failures in CI, or understanding the three testing layers (Kind cluster, Tekton integration, ShellSpec).
+---
+
+# Testing Tasks
+
+## Overview
+
+This repo has three distinct testing layers, each with different setup, triggers, and purposes. Kind cluster tests validate tasks in a local environment; Tekton integration tests verify behavior in the Konflux cluster; ShellSpec tests validate embedded bash scripts in isolation.
+
+## When to Use
+
+- Writing a test for a new or modified task
+- Running tests locally before pushing
+- "Run Task Tests" workflow fails in CI
+- Tekton integration test in `.tekton/integration/` fails
+- Debugging a task's step behavior
+- Understanding test infrastructure and patterns
+
+## Testing Layers Summary
+
+| Layer | Location | Trigger | Runs Where | When to Use |
+|-------|----------|---------|-----------|------------|
+| Kind cluster tests | `task/<name>/tests/` | GH Actions on PR (task/ changes) | Kind cluster in GH runner | Quick validation, dry-run syntax check |
+| Tekton integration tests | `.tekton/integration/test-*.yaml` | Konflux CI on PR (CEL-filtered) | Konflux cluster | Full pipeline integration, result validation |
+| ShellSpec unit tests | `task/<name>/spec/*_spec.sh` | Manual via `hack/test-shellspec.sh` | Local shell | Individual step logic, edge cases |
+
+## Kind Cluster Tests
+
+**When tests run:** GitHub Actions triggers on any PR modifying files in `task/` directory.
+
+**Workflow:** `.github/workflows/run-task-tests.yaml` (templated from task-repo-shared-ci)
+
+**How it works:**
+
+1. Detects changed task directories
+2. For each task with a `tests/` directory: runs `test-*.yaml` pipelines
+3. Test script: `.github/scripts/test_tekton_tasks.sh`
+4. Validation script (dry-run): `.github/scripts/check_tekton_tasks.sh`
+
+### Writing a Kind Test
+
+**Step 1:** Create directory
+
+```bash
+mkdir -p task/<task-name>/tests
+```
+
+**Step 2:** Create test pipeline
+
+`task/<task-name>/tests/test-<task-name>.yaml` must be a Tekton Pipeline:
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-<task-name>
+spec:
+  workspaces:
+    - name: tests-workspace  # REQUIRED - test framework provides this workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: <task-name>
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      params:
+        - name: image-url
+          value: "registry/image:tag"
+        # IMPORTANT: All task params must be declared here, even if using defaults.
+        # Omitting a param with a default will cause the test pipeline to fail.
+        # - name: my-other-param
+        #   value: "default-or-override-value"
+```
+
+**Step 3 (optional):** Create pre-apply hook
+
+`task/<task-name>/tests/pre-apply-task-hook.sh` (optional) runs before task apply:
+
+```bash
+#!/bin/bash
+
+TASK_COPY="$1"      # Path to temp copy of task YAML
+TEST_NS="$2"        # Test namespace name
+
+# Example: remove computeResources for constrained environment
+yq -i eval '.spec.steps[0].computeResources = {}' "$TASK_COPY"
+yq -i eval '.spec.steps[1].computeResources = {}' "$TASK_COPY"
+
+# Create secrets if needed
+echo '{"auths":{}}' | kubectl create secret generic docker-secret \
+  --from-file=.dockerconfigjson=/dev/stdin \
+  --type=kubernetes.io/dockerconfigjson \
+  -n "$TEST_NS" --dry-run=client -o yaml | kubectl apply -f - -n "$TEST_NS"
+```
+
+**Step 4:** Test discovers tests by glob `test-*.yaml` automatically.
+
+### Running Kind Tests Locally
+
+Prerequisites: kind, kubectl, tkn CLI, Tekton installed
+
+```bash
+# Create a Kind cluster
+kind create cluster
+
+# Deploy Tekton
+kubectl apply -f https://github.com/tektoncd/pipeline/releases/latest/download/release.yaml
+
+# Run tests
+./.github/scripts/test_tekton_tasks.sh task/<task-name>
+```
+
+### Namespace Isolation
+
+Each test runs in its own namespace: `<task-name>-<version-with-hyphens>`
+
+Test workspace is provided automatically with a claim template.
+
+## Tekton Integration Tests
+
+**Location:** `.tekton/integration/test-*.yaml`
+
+**Purpose:** Validate task results structure in Konflux pipelines. These are PipelineRun definitions triggered by Pipelines-as-Code CEL expressions.
+
+**Example:** `.tekton/integration/test-clair-scan.yaml` validates:
+
+- `TEST_OUTPUT` result (JSON with result, note, timestamp)
+- `SCAN_OUTPUT` result (JSON with vulnerability counts)
+- `IMAGES_PROCESSED` result
+- `REPORTS` result (OCI artifact digests)
+
+**Result validation pattern:**
+
+```yaml
+finally:
+  - name: check-results
+    taskSpec:
+      steps:
+        - name: validate
+          image: alpine:latest
+          script: |
+            # Validate TEST_OUTPUT structure
+            echo '$(tasks.run-scan.results.TEST_OUTPUT)' | jq '.result'
+            # Validate SCAN_OUTPUT has vulnerabilities
+            echo '$(tasks.run-scan.results.SCAN_OUTPUT)' | jq '.vulnerabilities'
+```
+
+## ShellSpec Unit Tests
+
+**Location:** `task/<task-name>/spec/*_spec.sh`
+
+**Framework:** ShellSpec (shell script testing framework)
+
+**Run locally:**
+
+```bash
+hack/test-shellspec.sh
+```
+
+**How it works:** Extracts step scripts from task YAML, tests them in isolation.
+
+**Example spec file:**
+
+```bash
+# task/my-task/spec/check_script_spec.sh
+
+Describe "check-script function"
+  setup() {
+    # Source the script or define functions
+    eval "$(yq eval '.spec.steps[0].script' task/my-task/my-task.yaml)"
+  }
+
+  It "validates image URL"
+    setup
+    When call check_image_url "quay.io/my/image:tag"
+    The status should be success
+  End
+
+  It "fails on invalid URL"
+    setup
+    When call check_image_url "invalid"
+    The status should be failure
+  End
+End
+```
+
+## Common Test Failures
+
+| Symptom | Likely Cause | Debug |
+|---------|-------------|-------|
+| "tests dir does not exist" | No `tests/` directory in changed task | Create `tests/test-*.yaml` pipeline |
+| Pipeline timeout | computeResources too high for runner | Add `pre-apply-task-hook.sh` to lower limits |
+| "Task validation failed" (dry-run) | Invalid task YAML syntax | `kubectl apply -f task.yaml --dry-run=server` |
+| Result validation fails | Task output format changed | Check jq assertions in `.tekton/integration/test-*.yaml` |
+| ShellSpec test fails | Script uses undefined variables | Check for unset env vars in isolated context |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Test file not named `test-*.yaml` | Script discovers by glob only. Rename to `test-<name>.yaml`. |
+| Missing `tests-workspace` workspace | Test framework provides storage for this name. Must be declared in Pipeline. |
+| Resource limits too high | Use `pre-apply-task-hook.sh` to zero out `computeResources` for Kind. |
+| Editing templated test scripts | `.github/scripts/test_tekton_tasks.sh` comes from task-repo-shared-ci. PR upstream instead. |
+| Task params not declared in test | Test Pipeline must declare all params the task needs. |
+| Ignoring test failures locally | Local tests must pass before pushing. CI will run same tests. |


### PR DESCRIPTION
  Summary                                                                                                                                                                                                          
                                                                       
  ✅ 6 AI skills created for konflux-ci/konflux-test-tasks:                                                                                                                                                        
                                                                       
  1. task-versioning-and-migration — Version labels, CHANGELOG.md, migration scripts with pmt modify, kustomized variant updates                                                                                   
  2. testing-tasks — Kind cluster tests, Tekton integration tests, ShellSpec unit tests, test debugging
  3. pr-definition-of-done — Pre-push checklist for all 14+ CI checks, commit conventions, generated files                                                                                                         
  4. ci-cd-quirks — Templated files, bundle tagging, Checkton, migration validation, kustomize, trusted artifacts
  5. task-generator-usage — Go generators for remote and TA variants, recipe.yaml format, generation pipeline                                                                                                      
  6. debugging-task-failures — Task result JSON schemas, runner images, common failures, OCI artifact attachment
                                                                                                                                                                                                                   
  ✅ Directory structure:                
  - skills/SKILLS.md — index with skill table + setup instructions                                                                                                                                                 
  - skills/<skill-name>/SKILL.md — 6 skill files with YAML frontmatter 
  - .claude/skills/ — 6 relative symlinks to skills/ (Claude Code auto-discovery)                                                                                                                                  
                                                                                                                                                                                                                   
  ✅ Committed to branch: [STONEINTG-1642 ](https://redhat.atlassian.net/browse/STONEINTG-1642)                                                                                                                                                                          

