### PR TITLE
feat(STONEINTG-1579): create pickle-scan tekton task

### DIFF
--- a/.tekton/pickle-scan-v01-pull-request.yaml
+++ b/.tekton/pickle-scan-v01-pull-request.yaml
@@ -1,0 +1,299 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/konflux-test-tasks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "task/pickle-scan/0.1/***".pathChanged() || ".tekton/pickle-scan-v01-pull-request.yaml".pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: konflux-test-tasks
+    appstudio.openshift.io/component: pickle-scan-v01
+    pipelines.appstudio.openshift.io/type: build
+  name: pickle-scan-v01-on-pull-request
+  namespace: rhtap-integration-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rhtap-integration-tenant/pickle-scan-v01:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: task/pickle-scan/0.1
+  pipelineSpec:
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description: Path to the source code of an application's component from where
+          to build image.
+        name: path-context
+        type: string
+      - default: Dockerfile
+        description: Path to the Dockerfile inside the context specified by parameter
+          path-context
+        name: dockerfile
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "false"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched
+        name: prefetch-input
+        type: string
+      - default: ""
+        description: Image tag expiration time, time values could be something like
+          1h, 2d, 3w for hours, days, and weeks, respectively.
+        name: image-expires-after
+        type: string
+      - default: "false"
+        description: Build a source image.
+        name: build-source-image
+        type: string
+      - default: "false"
+        description: Add built image into an OCI image index
+        name: build-image-index
+        type: string
+      - default: "false"
+        description: Enable cache proxy configuration
+        name: enable-cache-proxy
+      - name: enable-package-registry-proxy
+        default: 'true'
+        description: Use the package registry proxy when prefetching dependencies
+        type: string
+      - name: sast-target-dirs
+        type: string
+        default: .
+        description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        params:
+          - name: enable-cache-proxy
+            value: $(params.enable-cache-proxy)
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - name: prefetch-dependencies
+        params:
+          - name: input
+            value: $(params.prefetch-input)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+          - name: enable-package-registry-proxy
+            value: $(params.enable-package-registry-proxy)
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: prefetch-dependencies-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: git-basic-auth
+            workspace: git-auth
+          - name: netrc
+            workspace: netrc
+      - name: build-container
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: CONTEXT
+            value: $(params.path-context)
+          - name: URL
+            value: $(params.git-url)
+          - name: REVISION
+            value: $(params.revision)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        runAfter:
+          - prefetch-dependencies
+        taskRef:
+          params:
+            - name: name
+              value: tkn-bundle-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:35ebaaa9ad1b44086f5d92805a5b2eaa8ff26cb9516b7212b64c6b0caf0b6440
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: build-image-index
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: ALWAYS_BUILD_INDEX
+            value: $(params.build-image-index)
+          - name: IMAGES
+            value:
+              - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        runAfter:
+          - build-container
+        taskRef:
+          params:
+            - name: name
+              value: build-image-index
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: sast-shell-check
+        params:
+          - name: image-digest
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: TARGET_DIRS
+            value: $(params.sast-target-dirs)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: sast-shell-check-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:e5319fccebd21a1b06eb8fa6a46b78d745ce87464ed2cdd08b5f68a4489e2f14
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: sast-unicode-check
+        params:
+          - name: image-digest
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: TARGET_DIRS
+            value: $(params.sast-target-dirs)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: sast-unicode-check-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:99cc3729af9c3e1e6821e07e4d46cc0366a43d53cfba42846c0461abb68b5362
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: apply-tags
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: apply-tags
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
+            - name: kind
+              value: task
+          resolver: bundles
+    workspaces:
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pickle-scan-v01
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/pickle-scan-v01-push.yaml
+++ b/.tekton/pickle-scan-v01-push.yaml
@@ -1,0 +1,296 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/konflux-test-tasks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "task/pickle-scan/0.1/***".pathChanged() || ".tekton/pickle-scan-v01-push.yaml".pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: konflux-test-tasks
+    appstudio.openshift.io/component: pickle-scan-v01
+    pipelines.appstudio.openshift.io/type: build
+  name: pickle-scan-v01-on-push
+  namespace: rhtap-integration-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rhtap-integration-tenant/pickle-scan-v01:{{revision}}
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: task/pickle-scan/0.1
+  pipelineSpec:
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description: Path to the source code of an application's component from where
+          to build image.
+        name: path-context
+        type: string
+      - default: Dockerfile
+        description: Path to the Dockerfile inside the context specified by parameter
+          path-context
+        name: dockerfile
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "false"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched
+        name: prefetch-input
+        type: string
+      - default: ""
+        description: Image tag expiration time, time values could be something like
+          1h, 2d, 3w for hours, days, and weeks, respectively.
+        name: image-expires-after
+        type: string
+      - default: "false"
+        description: Build a source image.
+        name: build-source-image
+        type: string
+      - default: "false"
+        description: Add built image into an OCI image index
+        name: build-image-index
+        type: string
+      - default: "false"
+        description: Enable cache proxy configuration
+        name: enable-cache-proxy
+      - name: enable-package-registry-proxy
+        default: 'true'
+        description: Use the package registry proxy when prefetching dependencies
+        type: string
+      - name: sast-target-dirs
+        type: string
+        default: .
+        description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        params:
+          - name: enable-cache-proxy
+            value: $(params.enable-cache-proxy)
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - name: prefetch-dependencies
+        params:
+          - name: input
+            value: $(params.prefetch-input)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+          - name: enable-package-registry-proxy
+            value: $(params.enable-package-registry-proxy)
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: prefetch-dependencies-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: git-basic-auth
+            workspace: git-auth
+          - name: netrc
+            workspace: netrc
+      - name: build-container
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: CONTEXT
+            value: $(params.path-context)
+          - name: URL
+            value: $(params.git-url)
+          - name: REVISION
+            value: $(params.revision)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        runAfter:
+          - prefetch-dependencies
+        taskRef:
+          params:
+            - name: name
+              value: tkn-bundle-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:35ebaaa9ad1b44086f5d92805a5b2eaa8ff26cb9516b7212b64c6b0caf0b6440
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: build-image-index
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: ALWAYS_BUILD_INDEX
+            value: $(params.build-image-index)
+          - name: IMAGES
+            value:
+              - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        runAfter:
+          - build-container
+        taskRef:
+          params:
+            - name: name
+              value: build-image-index
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: sast-shell-check
+        params:
+          - name: image-digest
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: TARGET_DIRS
+            value: $(params.sast-target-dirs)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: sast-shell-check-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:e5319fccebd21a1b06eb8fa6a46b78d745ce87464ed2cdd08b5f68a4489e2f14
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: sast-unicode-check
+        params:
+          - name: image-digest
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: TARGET_DIRS
+            value: $(params.sast-target-dirs)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: sast-unicode-check-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:99cc3729af9c3e1e6821e07e4d46cc0366a43d53cfba42846c0461abb68b5362
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: apply-tags
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: apply-tags
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
+            - name: kind
+              value: task
+          resolver: bundles
+    workspaces:
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pickle-scan-v01
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,5 +6,7 @@
 /task/clamav-scan                               @konflux-ci/integration-service-maintainers
 /task/clamav-scan-min                           @konflux-ci/integration-service-maintainers
 /task/deprecated-image-check                    @konflux-ci/integration-service-maintainers
+/task/pickle-scan                               @konflux-ci/integration-service-maintainers
+/task/pickle-scan-oci-ta                        @konflux-ci/integration-service-maintainers
 /task/roxctl-scan                               @konflux-ci/integration-service-maintainers
 /task/tpa-scan                                  @konflux-ci/integration-service-maintainers

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,8 @@
         "task/clamav-scan-min/**",
         "task/clamav-scan/**",
         "task/deprecated-image-check/**",
+        "task/pickle-scan-oci-ta/**",
+        "task/pickle-scan/**",
         "task/roxctl-scan/**",
         "task/tpa-scan/**"
       ]

--- a/task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
+++ b/task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
@@ -1,0 +1,247 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: pickle-scan-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: pickle, security, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: Scans OCI artifacts and AI model files for malicious pickle
+    files using picklescan. Uses trusted artifacts for source data. Pickle
+    files are commonly used for Python/ML model serialization and can contain
+    arbitrary code execution payloads.
+  params:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: ca-trust-config-map-key
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: ca-trust-config-map-name
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: image-digest
+      description: Image digest to scan.
+    - name: image-url
+      description: Image URL.
+    - name: skip-oci-attach-report
+      description: If true, skips uploading the results to the image registry.
+        Useful for read-only tests.
+      type: string
+      default: "false"
+  results:
+    - name: IMAGES_PROCESSED
+      description: Images processed in the task.
+    - name: SCAN_OUTPUT
+      description: Pickle scan result.
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.ca-trust-config-map-key)
+            path: ca-bundle.crt
+        name: $(params.ca-trust-config-map-name)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        name: trusted-ca
+        readOnly: true
+        subPath: ca-bundle.crt
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:13ccf533248a98558cc7705e148c1c92e29f95ad67b5c0f4a9df5f57e051d276
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: pickle-scan
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      workingDir: /tekton/home
+      env:
+        - name: SOURCE_PATH
+          value: /var/workdir/source
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        echo '{}' >"$(results.SCAN_OUTPUT.path)"
+
+        if [ ! -d "$SOURCE_PATH" ]; then
+          note="Task $(context.task.name) failed: Source directory not found at $SOURCE_PATH."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          touch /tekton/home/pickle-scan-error
+          exit 0
+        fi
+
+        echo "Running picklescan on $SOURCE_PATH"
+        set +o pipefail
+        picklescan --path "$SOURCE_PATH" 2>&1 | tee /tekton/home/picklescan-output.txt
+        picklescan_exit=${PIPESTATUS[0]}
+        set -o pipefail
+
+        if [ "$picklescan_exit" -gt 1 ]; then
+          note="Task $(context.task.name) failed: picklescan exited with code $picklescan_exit."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          touch /tekton/home/pickle-scan-error
+          exit 0
+        fi
+
+        if [ ! -s /tekton/home/picklescan-output.txt ]; then
+          note="Task $(context.task.name) failed: picklescan produced no output."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          touch /tekton/home/pickle-scan-error
+          exit 0
+        fi
+
+        parse_picklescan_output /tekton/home/picklescan-output.txt >/tekton/home/picklescan-report.json
+
+        if ! jq -e '.infected_files and .summary' /tekton/home/picklescan-report.json >/dev/null 2>&1; then
+          note="Task $(context.task.name) failed: picklescan report is missing expected fields."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          touch /tekton/home/pickle-scan-error
+          exit 0
+        fi
+
+        echo "Pickle scan report:"
+        cat /tekton/home/picklescan-report.json
+
+        if jq -e '.infected_files | length > 0' /tekton/home/picklescan-report.json >/dev/null 2>&1; then
+          echo ""
+          echo "WARNING: Infected files detected:"
+          jq -r '.infected_files | to_entries[] | "  \(.key): \(.value)"' /tekton/home/picklescan-report.json
+        fi
+      computeResources:
+        limits:
+          cpu: 800m
+          memory: 2Gi
+        requests:
+          cpu: 800m
+          memory: 2Gi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+    - name: oci-attach-report
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      workingDir: /tekton/home
+      env:
+        - name: SKIP_OCI_ATTACH_REPORT
+          value: $(params.skip-oci-attach-report)
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [ "$SKIP_OCI_ATTACH_REPORT" = "true" ]; then
+          echo "OCI attach report skipped by parameter."
+          exit 0
+        fi
+
+        if [ ! -f /tekton/home/picklescan-report.json ]; then
+          echo "No pickle scan report found. Skipping upload."
+          exit 0
+        fi
+
+        imagewithouttag=$(echo -n "$IMAGE_URL" | sed "s/\(.*\):.*/\1/")
+        imageanddigest="${imagewithouttag}@${IMAGE_DIGEST}"
+
+        mkdir -p /tmp/auth && select-oci-auth "${imageanddigest}" >/tmp/auth/config.json
+        export DOCKER_CONFIG=/tmp/auth
+
+        MEDIA_TYPE="application/vnd.redhat.pickle-scan-report+json"
+
+        echo "Attaching pickle scan report to ${imageanddigest}"
+        retry oras attach --no-tty --registry-config "/tmp/auth/config.json" \
+          --artifact-type "${MEDIA_TYPE}" \
+          "${imageanddigest}" \
+          "/tekton/home/picklescan-report.json:${MEDIA_TYPE}"
+      computeResources:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+    - name: evaluate-policy
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      workingDir: /tekton/home
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        if [ -f /tekton/home/pickle-scan-error ]; then
+          echo "Previous step failed. Preserving its TEST_OUTPUT."
+          exit 0
+        fi
+
+        if [ ! -f /tekton/home/picklescan-report.json ]; then
+          note="Task $(context.task.name) failed: No pickle scan report found."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        if ! jq -ce '.summary' /tekton/home/picklescan-report.json >"$(results.SCAN_OUTPUT.path)"; then
+          note="Task $(context.task.name) failed: Pickle scan report missing .summary field."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # Use ec test (not conftest) so the rego policy drives TEST_OUTPUT directly,
+        # matching the clamav-scan pattern and avoiding dead-code re-derivation from raw counts.
+        # Note: this changes the TEST_OUTPUT shape from make_result_json to ec's appstudio format.
+        EC_EXPERIMENTAL=1 ec test \
+          --namespace required_checks \
+          --policy /project/picklescan/virus-check.rego \
+          -o appstudio \
+          /tekton/home/picklescan-report.json | tee /tekton/home/picklescan-ec-test.json || true
+
+        if [ ! -s /tekton/home/picklescan-ec-test.json ]; then
+          note="Task $(context.task.name) failed: Policy evaluation did not produce output."
+          TEST_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        jq -rce '.' /tekton/home/picklescan-ec-test.json | tee "$(results.TEST_OUTPUT.path)"
+
+        echo '{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": ["'"$IMAGE_DIGEST"'"]}}' | tee "$(results.IMAGES_PROCESSED.path)"
+      computeResources:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/task/pickle-scan-oci-ta/0.1/recipe.yaml
+++ b/task/pickle-scan-oci-ta/0.1/recipe.yaml
@@ -1,0 +1,13 @@
+---
+base: ../../pickle-scan/0.1/pickle-scan.yaml
+add:
+  - use-source
+removeWorkspaces:
+  - source
+replacements:
+  workspaces.source.path: /var/workdir/source
+description: >-
+  Scans OCI artifacts and AI model files for malicious pickle files
+  using picklescan. Uses trusted artifacts for source data.
+  Pickle files are commonly used for Python/ML model serialization
+  and can contain arbitrary code execution payloads.

--- a/task/pickle-scan-oci-ta/CHANGELOG.md
+++ b/task/pickle-scan-oci-ta/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
+
+## 0.1
+
+### Added
+
+- Initial release of pickle-scan-oci-ta task (trusted artifacts variant)
+- Scans OCI artifacts and AI model files for malicious pickle content using picklescan
+- Attaches scan report to OCI image registry
+- Generates TEST_OUTPUT and SCAN_OUTPUT results via rego policy evaluation

--- a/task/pickle-scan/0.1/README.md
+++ b/task/pickle-scan/0.1/README.md
@@ -1,0 +1,31 @@
+# pickle-scan task
+
+## Description:
+
+Scans OCI artifacts and AI model files for malicious pickle files using
+[picklescan](https://github.com/mmaitre314/picklescan). Pickle files are
+commonly used for Python/ML model serialization and can contain arbitrary
+code execution payloads.
+
+## Params:
+
+| Name | Description | Default |
+|------|-------------|---------|
+| image-url | Image URL | (required) |
+| image-digest | Image digest to scan | (required) |
+| ca-trust-config-map-name | ConfigMap name for CA bundle | `trusted-ca` |
+| ca-trust-config-map-key | Key in ConfigMap for CA bundle | `ca-bundle.crt` |
+| skip-oci-attach-report | Skip uploading report to registry | `false` |
+
+## Workspaces
+
+| Name | Description |
+|------|-------------|
+| source | Directory containing model files to scan for malicious pickle content |
+
+## Results
+
+| Name | Description |
+|------|-------------|
+| TEST_OUTPUT | Tekton task test output |
+| SCAN_OUTPUT | Pickle scan result summary (scanned_files, infected_files, dangerous_globals) |

--- a/task/pickle-scan/0.1/kustomization.yaml
+++ b/task/pickle-scan/0.1/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pickle-scan.yaml

--- a/task/pickle-scan/0.1/pickle-scan.yaml
+++ b/task/pickle-scan/0.1/pickle-scan.yaml
@@ -1,0 +1,238 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "pickle, security, konflux"
+  name: pickle-scan
+spec:
+  description: >-
+    Scans OCI artifacts and AI model files for malicious pickle files
+    using picklescan. Pickle files are commonly used for Python/ML model
+    serialization and can contain arbitrary code execution payloads.
+  params:
+    - name: image-url
+      description: Image URL.
+    - name: image-digest
+      description: Image digest to scan.
+    - name: ca-trust-config-map-name
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: ca-trust-config-map-key
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+    - name: skip-oci-attach-report
+      type: string
+      description: If true, skips uploading the results to the image registry. Useful for read-only tests.
+      default: "false"
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+    - name: SCAN_OUTPUT
+      description: Pickle scan result.
+    - name: IMAGES_PROCESSED
+      description: Images processed in the task.
+  workspaces:
+    - name: source
+      description: Directory containing model files to scan for malicious pickle content.
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        subPath: ca-bundle.crt
+        readOnly: true
+  steps:
+    - name: pickle-scan
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      computeResources:
+        limits:
+          memory: 2Gi
+          cpu: 800m
+        requests:
+          memory: 2Gi
+          cpu: 800m
+      env:
+        - name: SOURCE_PATH
+          value: $(workspaces.source.path)
+      workingDir: /tekton/home
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+      # language=bash
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        echo '{}' > "$(results.SCAN_OUTPUT.path)"
+
+        if [ ! -d "$SOURCE_PATH" ]; then
+          note="Task $(context.task.name) failed: Source directory not found at $SOURCE_PATH."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          touch /tekton/home/pickle-scan-error
+          exit 0
+        fi
+
+        echo "Running picklescan on $SOURCE_PATH"
+        set +o pipefail
+        picklescan --path "$SOURCE_PATH" 2>&1 | tee /tekton/home/picklescan-output.txt
+        picklescan_exit=${PIPESTATUS[0]}
+        set -o pipefail
+
+        if [ "$picklescan_exit" -gt 1 ]; then
+          note="Task $(context.task.name) failed: picklescan exited with code $picklescan_exit."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          touch /tekton/home/pickle-scan-error
+          exit 0
+        fi
+
+        if [ ! -s /tekton/home/picklescan-output.txt ]; then
+          note="Task $(context.task.name) failed: picklescan produced no output."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          touch /tekton/home/pickle-scan-error
+          exit 0
+        fi
+
+        parse_picklescan_output /tekton/home/picklescan-output.txt > /tekton/home/picklescan-report.json
+
+        if ! jq -e '.infected_files and .summary' /tekton/home/picklescan-report.json > /dev/null 2>&1; then
+          note="Task $(context.task.name) failed: picklescan report is missing expected fields."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          touch /tekton/home/pickle-scan-error
+          exit 0
+        fi
+
+        echo "Pickle scan report:"
+        cat /tekton/home/picklescan-report.json
+
+        if jq -e '.infected_files | length > 0' /tekton/home/picklescan-report.json > /dev/null 2>&1; then
+          echo ""
+          echo "WARNING: Infected files detected:"
+          jq -r '.infected_files | to_entries[] | "  \(.key): \(.value)"' /tekton/home/picklescan-report.json
+        fi
+    - name: oci-attach-report
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      workingDir: /tekton/home
+      env:
+        - name: SKIP_OCI_ATTACH_REPORT
+          value: $(params.skip-oci-attach-report)
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      # language=bash
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [ "$SKIP_OCI_ATTACH_REPORT" = "true" ]; then
+          echo "OCI attach report skipped by parameter."
+          exit 0
+        fi
+
+        if [ ! -f /tekton/home/picklescan-report.json ]; then
+          echo "No pickle scan report found. Skipping upload."
+          exit 0
+        fi
+
+        imagewithouttag=$(echo -n "$IMAGE_URL" | sed "s/\(.*\):.*/\1/")
+        imageanddigest="${imagewithouttag}@${IMAGE_DIGEST}"
+
+        mkdir -p /tmp/auth && select-oci-auth "${imageanddigest}" > /tmp/auth/config.json
+        export DOCKER_CONFIG=/tmp/auth
+
+        MEDIA_TYPE="application/vnd.redhat.pickle-scan-report+json"
+
+        echo "Attaching pickle scan report to ${imageanddigest}"
+        retry oras attach --no-tty --registry-config "/tmp/auth/config.json" \
+          --artifact-type "${MEDIA_TYPE}" \
+          "${imageanddigest}" \
+          "/tekton/home/picklescan-report.json:${MEDIA_TYPE}"
+    - name: evaluate-policy
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      workingDir: /tekton/home
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      # language=bash
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        if [ -f /tekton/home/pickle-scan-error ]; then
+          echo "Previous step failed. Preserving its TEST_OUTPUT."
+          exit 0
+        fi
+
+        if [ ! -f /tekton/home/picklescan-report.json ]; then
+          note="Task $(context.task.name) failed: No pickle scan report found."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        if ! jq -ce '.summary' /tekton/home/picklescan-report.json > "$(results.SCAN_OUTPUT.path)"; then
+          note="Task $(context.task.name) failed: Pickle scan report missing .summary field."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # Use ec test (not conftest) so the rego policy drives TEST_OUTPUT directly,
+        # matching the clamav-scan pattern and avoiding dead-code re-derivation from raw counts.
+        # Note: this changes the TEST_OUTPUT shape from make_result_json to ec's appstudio format.
+        EC_EXPERIMENTAL=1 ec test \
+          --namespace required_checks \
+          --policy /project/picklescan/virus-check.rego \
+          -o appstudio \
+          /tekton/home/picklescan-report.json | tee /tekton/home/picklescan-ec-test.json || true
+
+        if [ ! -s /tekton/home/picklescan-ec-test.json ]; then
+          note="Task $(context.task.name) failed: Policy evaluation did not produce output."
+          TEST_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        jq -rce '.' /tekton/home/picklescan-ec-test.json | tee "$(results.TEST_OUTPUT.path)"
+
+        echo '{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": ["'"$IMAGE_DIGEST"'"]}}' | tee "$(results.IMAGES_PROCESSED.path)"
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.ca-trust-config-map-name)
+        items:
+          - key: $(params.ca-trust-config-map-key)
+            path: ca-bundle.crt
+        optional: true

--- a/task/pickle-scan/CHANGELOG.md
+++ b/task/pickle-scan/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
+
+## 0.1
+
+### Added
+
+- Initial release of pickle-scan task
+- Scans OCI artifacts and AI model files for malicious pickle content using picklescan
+- Attaches scan report to OCI image registry
+- Generates TEST_OUTPUT and SCAN_OUTPUT results via policy evaluation


### PR DESCRIPTION
Add pickle-scan task that scans OCI artifacts and
AI model files for malicious pickle content using
picklescan. The task produces TEST_OUTPUT
and SCAN_OUTPUT results via conftest policy
evaluation.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
