### PR TITLE
feat(STONEINTG-1581): add intg test pipeline for picklescan

### DIFF
--- a/.tekton/integration/test-pickle-scan.yaml
+++ b/.tekton/integration/test-pickle-scan.yaml
@@ -1,0 +1,201 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-pickle-scan
+  labels:
+    appstudio.openshift.io/application: konflux-test-tasks
+    appstudio.openshift.io/component: pickle-scan-v01
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: pickle-scan-workspace
+    description: |
+      Test the pickle-scan task by validating the expected results structure.
+    results:
+      - name: TEST_OUTPUT
+        value: "$(tasks.check-results.results.TEST_OUTPUT)"
+    tasks:
+      - name: setup-fixtures
+        workspaces:
+          - name: source
+            workspace: pickle-scan-workspace
+        taskSpec:
+          workspaces:
+            - name: source
+          steps:
+            - name: write-fixtures
+              image: quay.io/konflux-ci/konflux-test:v1.4.53@sha256:724ecf16a1fc9b51a1b20c91c5125556c53d471d0d8db1648d2404e4715f204e
+              script: |
+                #!/usr/bin/env bash
+                set -euo pipefail
+                fixture_dir="$(workspaces.source.path)"
+                echo "Writing fixtures to ${fixture_dir}"
+                # Harmless non-pickle file — proves picklescan runs on real content
+                echo "safe test fixture for pickle-scan integration test" > "${fixture_dir}/safe.txt"
+                ls -la "${fixture_dir}"
+      - name: pickle-scan
+        runAfter:
+          - setup-fixtures
+        workspaces:
+          - name: source
+            workspace: pickle-scan-workspace
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/konflux-ci/konflux-test-tasks.git
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: task/pickle-scan/0.1/pickle-scan.yaml
+        params:
+          - name: skip-oci-attach-report
+            value: "true"
+          - name: image-url
+            value: "quay.io/konflux-ci/konflux-test:v1.5.3"
+          - name: image-digest
+            value: "sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455"
+      - name: check-results
+        runAfter:
+          - pickle-scan
+        params:
+          - name: TEST_OUTPUT
+            value: "$(tasks.pickle-scan.results.TEST_OUTPUT)"
+          - name: SCAN_OUTPUT
+            value: "$(tasks.pickle-scan.results.SCAN_OUTPUT)"
+          - name: IMAGES_PROCESSED
+            value: "$(tasks.pickle-scan.results.IMAGES_PROCESSED)"
+        taskSpec:
+          params:
+            - name: TEST_OUTPUT
+            - name: SCAN_OUTPUT
+            - name: IMAGES_PROCESSED
+          results:
+            - name: TEST_OUTPUT
+              description: Test result output
+          steps:
+            - name: validate-results
+              image: quay.io/konflux-ci/konflux-test:v1.4.53@sha256:724ecf16a1fc9b51a1b20c91c5125556c53d471d0d8db1648d2404e4715f204e
+              env:
+                - name: TEST_OUTPUT
+                  value: "$(params.TEST_OUTPUT)"
+                - name: SCAN_OUTPUT
+                  value: "$(params.SCAN_OUTPUT)"
+                - name: IMAGES_PROCESSED
+                  value: "$(params.IMAGES_PROCESSED)"
+                - name: IMAGE_URL
+                  value: "quay.io/konflux-ci/konflux-test:v1.5.3"
+                - name: IMAGE_DIGEST
+                  value: "sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455"
+              script: |
+                #!/usr/bin/env bash
+                set -euo pipefail
+
+                echo "=== Validating pickle-scan task results ==="
+
+                # Validate TEST_OUTPUT structure
+                echo "--- Checking TEST_OUTPUT ---"
+                echo "$TEST_OUTPUT" | jq -e '
+                  has("result") and
+                  has("note") and
+                  has("timestamp") and
+                  (.result | IN("SUCCESS", "WARNING", "ERROR", "SKIPPED"))
+                ' > /dev/null || {
+                  echo "FAIL: TEST_OUTPUT missing required fields or invalid result"
+                  echo "Got: $TEST_OUTPUT"
+                  exit 1
+                }
+                result=$(echo "$TEST_OUTPUT" | jq -r '.result')
+                if [[ "$result" != "SUCCESS" && "$result" != "WARNING" ]]; then
+                  echo "FAIL: Expected result SUCCESS or WARNING, got: $result"
+                  exit 1
+                fi
+                echo "PASS: TEST_OUTPUT is valid with result=$result"
+
+
+                # Validate SCAN_OUTPUT structure
+                echo "--- Checking SCAN_OUTPUT ---"
+                echo "$SCAN_OUTPUT" | jq -e '
+                  has("scanned_files") and
+                  has("infected_files") and
+                  has("dangerous_globals")
+                ' > /dev/null || {
+                  echo "FAIL: SCAN_OUTPUT missing required fields"
+                  echo "Got: $SCAN_OUTPUT"
+                  exit 1
+                }
+                echo "PASS: SCAN_OUTPUT has required fields"
+
+                # Validate SCAN_OUTPUT fields are numbers
+                echo "$SCAN_OUTPUT" | jq -e '
+                  (.scanned_files | type) == "number" and
+                  (.infected_files | type) == "number" and
+                  (.dangerous_globals | type) == "number"' > /dev/null || {
+                  echo "FAIL: SCAN_OUTPUT fields are not numbers"
+                  echo "Got: $SCAN_OUTPUT"
+                  exit 1
+                }
+                echo "PASS: SCAN_OUTPUT fields are numbers"
+
+                scanned=$(echo "$SCAN_OUTPUT" | jq -r '.scanned_files')
+                if [[ "$scanned" -lt 1 ]]; then
+                  echo "FAIL: Expected at least 1 scanned file, got: $scanned"
+                  exit 1
+                fi
+                echo "PASS: picklescan scanned ${scanned} file(s)"
+                infected=$(echo "$SCAN_OUTPUT" | jq -r '.infected_files')
+                if [[ "$infected" -ne 0 ]]; then
+                  echo "FAIL: Expected 0 infected files for safe fixture, got: $infected"
+                  exit 1
+                fi
+                echo "PASS: No infected files"
+
+                # Validate IMAGES_PROCESSED structure
+                echo "--- Checking IMAGES_PROCESSED ---"
+                echo "$IMAGES_PROCESSED" | jq -e '
+                  has("image") and
+                  (.image | has("pullspec", "digests")) and
+                  (.image.digests | type) == "array" and
+                  (.image.digests | length) > 0
+                ' > /dev/null || {
+                  echo "FAIL: IMAGES_PROCESSED missing required fields"
+                  echo "Got: $IMAGES_PROCESSED"
+                  exit 1
+                }
+
+                # Verify pullspec matches input
+                pullspec=$(echo "$IMAGES_PROCESSED" | jq -r '.image.pullspec')
+                if [[ "$pullspec" != "$IMAGE_URL" ]]; then
+                  echo "FAIL: IMAGES_PROCESSED pullspec mismatch"
+                  echo "Expected: $IMAGE_URL"
+                  echo "Got: $pullspec"
+                  exit 1
+                fi
+
+                # Verify digest is in the list
+                if ! echo "$IMAGES_PROCESSED" | jq -e \
+                  --arg digest "$IMAGE_DIGEST" '.image.digests | index($digest) != null' > /dev/null; then
+                  echo "FAIL: IMAGE_DIGEST not found in IMAGES_PROCESSED digests"
+                  echo "Expected digest: $IMAGE_DIGEST"
+                  echo "Got digests: $(echo "$IMAGES_PROCESSED" | jq '.image.digests')"
+                  exit 1
+                fi
+                echo "PASS: IMAGES_PROCESSED is valid"
+                echo "$IMAGES_PROCESSED" | jq '.'
+
+                echo ""
+                echo "=== All pickle-scan validations passed ==="
+                echo -n "$TEST_OUTPUT" > "$(results.TEST_OUTPUT.path)"
+  workspaces:
+    - name: pickle-scan-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Mi
+  timeouts:
+    pipeline: 1h0m0s
+    tasks: 45m0s

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Currently available integration tests:
 - `test-clair-scan.yaml` - Validates the clair-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-clamav-scan.yaml` - Validates the clamav-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-deprecated-image.yaml` - Validates the deprecated-image-check task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
+- `test-pickle-scan.yaml` - Validates the pickle-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED)
 - `test-roxctl-scan.yaml` - Validates the roxctl-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-tpa-scan.yaml` - Validates the tpa-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `validate-migration.yaml` - Validates the migration file introduced by a branch


### PR DESCRIPTION
 - add integration test pipeline for picklescan
 - test depends on https://github.com/konflux-ci/konflux-test-tasks/pull/525 
 - updated readme to include `test-pickle-scan.yaml`

assisted-by-ai: cursor-ai

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
