### PR TITLE
fix(STONEINTG-1708): remove SCAN_OUTPUT in pickle-scan

### DIFF
--- a/.tekton/integration/test-pickle-scan.yaml
+++ b/.tekton/integration/test-pickle-scan.yaml
@@ -25,7 +25,7 @@ spec:
             - name: source
           steps:
             - name: write-fixtures
-              image: quay.io/konflux-ci/konflux-test:v1.4.53@sha256:724ecf16a1fc9b51a1b20c91c5125556c53d471d0d8db1648d2404e4715f204e
+              image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
               script: |
                 #!/usr/bin/env bash
                 set -euo pipefail
@@ -76,7 +76,7 @@ spec:
               description: Test result output
           steps:
             - name: validate-results
-              image: quay.io/konflux-ci/konflux-test:v1.4.53@sha256:724ecf16a1fc9b51a1b20c91c5125556c53d471d0d8db1648d2404e4715f204e
+              image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
               env:
                 - name: TEST_OUTPUT
                   value: "$(params.TEST_OUTPUT)"

--- a/.tekton/integration/test-pickle-scan.yaml
+++ b/.tekton/integration/test-pickle-scan.yaml
@@ -62,14 +62,11 @@ spec:
         params:
           - name: TEST_OUTPUT
             value: "$(tasks.pickle-scan.results.TEST_OUTPUT)"
-          - name: SCAN_OUTPUT
-            value: "$(tasks.pickle-scan.results.SCAN_OUTPUT)"
           - name: IMAGES_PROCESSED
             value: "$(tasks.pickle-scan.results.IMAGES_PROCESSED)"
         taskSpec:
           params:
             - name: TEST_OUTPUT
-            - name: SCAN_OUTPUT
             - name: IMAGES_PROCESSED
           results:
             - name: TEST_OUTPUT
@@ -80,8 +77,6 @@ spec:
               env:
                 - name: TEST_OUTPUT
                   value: "$(params.TEST_OUTPUT)"
-                - name: SCAN_OUTPUT
-                  value: "$(params.SCAN_OUTPUT)"
                 - name: IMAGES_PROCESSED
                   value: "$(params.IMAGES_PROCESSED)"
                 - name: IMAGE_URL
@@ -106,50 +101,27 @@ spec:
                   echo "Got: $TEST_OUTPUT"
                   exit 1
                 }
+
                 result=$(echo "$TEST_OUTPUT" | jq -r '.result')
-                if [[ "$result" != "SUCCESS" && "$result" != "WARNING" ]]; then
-                  echo "FAIL: Expected result SUCCESS or WARNING, got: $result"
+                if [[ "$result" != "SUCCESS" ]]; then
+                  echo "FAIL: Expected result SUCCESS, got: $result"
                   exit 1
                 fi
                 echo "PASS: TEST_OUTPUT is valid with result=$result"
 
-
-                # Validate SCAN_OUTPUT structure
-                echo "--- Checking SCAN_OUTPUT ---"
-                echo "$SCAN_OUTPUT" | jq -e '
-                  has("scanned_files") and
-                  has("infected_files") and
-                  has("dangerous_globals")
-                ' > /dev/null || {
-                  echo "FAIL: SCAN_OUTPUT missing required fields"
-                  echo "Got: $SCAN_OUTPUT"
-                  exit 1
-                }
-                echo "PASS: SCAN_OUTPUT has required fields"
-
-                # Validate SCAN_OUTPUT fields are numbers
-                echo "$SCAN_OUTPUT" | jq -e '
-                  (.scanned_files | type) == "number" and
-                  (.infected_files | type) == "number" and
-                  (.dangerous_globals | type) == "number"' > /dev/null || {
-                  echo "FAIL: SCAN_OUTPUT fields are not numbers"
-                  echo "Got: $SCAN_OUTPUT"
-                  exit 1
-                }
-                echo "PASS: SCAN_OUTPUT fields are numbers"
-
-                scanned=$(echo "$SCAN_OUTPUT" | jq -r '.scanned_files')
-                if [[ "$scanned" -lt 1 ]]; then
-                  echo "FAIL: Expected at least 1 scanned file, got: $scanned"
+                failures=$(echo "$TEST_OUTPUT" | jq -r '.failures')
+                if [[ "$failures" != "0" ]]; then
+                  echo "FAIL: Expected 0 failures in TEST_OUTPUT, got: $failures"
                   exit 1
                 fi
-                echo "PASS: picklescan scanned ${scanned} file(s)"
-                infected=$(echo "$SCAN_OUTPUT" | jq -r '.infected_files')
-                if [[ "$infected" -ne 0 ]]; then
-                  echo "FAIL: Expected 0 infected files for safe fixture, got: $infected"
+                echo "PASS: TEST_OUTPUT is valid with failures=$failures"
+
+                successes=$(echo "$TEST_OUTPUT" | jq -r '.successes')
+                if [[ "$successes" != "1" ]]; then
+                  echo "FAIL: Expected 1 successes in TEST_OUTPUT, got: $successes"
                   exit 1
                 fi
-                echo "PASS: No infected files"
+                echo "PASS: TEST_OUTPUT is valid with successes=$successes"
 
                 # Validate IMAGES_PROCESSED structure
                 echo "--- Checking IMAGES_PROCESSED ---"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Currently available integration tests:
 - `test-clair-scan.yaml` - Validates the clair-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-clamav-scan.yaml` - Validates the clamav-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-deprecated-image.yaml` - Validates the deprecated-image-check task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
-- `test-pickle-scan.yaml` - Validates the pickle-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED)
+- `test-pickle-scan.yaml` - Validates the pickle-scan task outputs (TEST_OUTPUT, IMAGES_PROCESSED)
 - `test-roxctl-scan.yaml` - Validates the roxctl-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-tpa-scan.yaml` - Validates the tpa-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `validate-migration.yaml` - Validates the migration file introduced by a branch

--- a/task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
+++ b/task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: pickle, security, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: 0.1.1
 spec:
   description: Scans OCI artifacts and AI model files for malicious pickle
     files using picklescan. Uses trusted artifacts for source data. Pickle
@@ -39,8 +39,6 @@ spec:
   results:
     - name: IMAGES_PROCESSED
       description: Images processed in the task.
-    - name: SCAN_OUTPUT
-      description: Pickle scan result.
     - name: TEST_OUTPUT
       description: Tekton task test output.
   volumes:
@@ -79,8 +77,6 @@ spec:
         # shellcheck source=/dev/null
         . /utils.sh
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-        echo '{}' >"$(results.SCAN_OUTPUT.path)"
 
         if [ ! -d "$SOURCE_PATH" ]; then
           note="Task $(context.task.name) failed: Source directory not found at $SOURCE_PATH."
@@ -212,7 +208,7 @@ spec:
           exit 0
         fi
 
-        if ! jq -ce '.summary' /tekton/home/picklescan-report.json >"$(results.SCAN_OUTPUT.path)"; then
+        if ! jq -ce .summary /tekton/home/picklescan-report.json >/dev/null; then
           note="Task $(context.task.name) failed: Pickle scan report missing .summary field."
           ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
           echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"

--- a/task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
+++ b/task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
@@ -68,7 +68,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: pickle-scan
-      image: quay.io/konflux-ci/konflux-test:v1.5.3@sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455
+      image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
       workingDir: /tekton/home
       env:
         - name: SOURCE_PATH
@@ -186,7 +186,7 @@ spec:
           cpu: 100m
           memory: 256Mi
     - name: evaluate-policy
-      image: quay.io/konflux-ci/konflux-test:v1.5.3@sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455
+      image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
       workingDir: /tekton/home
       env:
         - name: IMAGE_URL

--- a/task/pickle-scan-oci-ta/CHANGELOG.md
+++ b/task/pickle-scan-oci-ta/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
 
+## 0.1.1
+
+### Removed
+
+- SCAN_OUTPUT result has been removed as it wasn't compatible with standardized Konflux UI
+
 ## 0.1
 
 ### Added

--- a/task/pickle-scan/0.1/README.md
+++ b/task/pickle-scan/0.1/README.md
@@ -28,4 +28,3 @@ code execution payloads.
 | Name | Description |
 |------|-------------|
 | TEST_OUTPUT | Tekton task test output |
-| SCAN_OUTPUT | Pickle scan result summary (scanned_files, infected_files, dangerous_globals) |

--- a/task/pickle-scan/0.1/pickle-scan.yaml
+++ b/task/pickle-scan/0.1/pickle-scan.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.1.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "pickle, security, konflux"
@@ -33,8 +33,6 @@ spec:
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.
-    - name: SCAN_OUTPUT
-      description: Pickle scan result.
     - name: IMAGES_PROCESSED
       description: Images processed in the task.
   workspaces:
@@ -200,7 +198,7 @@ spec:
           exit 0
         fi
 
-        if ! jq -ce '.summary' /tekton/home/picklescan-report.json > "$(results.SCAN_OUTPUT.path)"; then
+        if ! jq -ce .summary /tekton/home/picklescan-report.json > /dev/null; then
           note="Task $(context.task.name) failed: Pickle scan report missing .summary field."
           ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
           echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"

--- a/task/pickle-scan/0.1/pickle-scan.yaml
+++ b/task/pickle-scan/0.1/pickle-scan.yaml
@@ -48,7 +48,7 @@ spec:
         readOnly: true
   steps:
     - name: pickle-scan
-      image: quay.io/konflux-ci/konflux-test:v1.5.3@sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455
+      image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
       computeResources:
         limits:
           memory: 2Gi
@@ -71,8 +71,6 @@ spec:
         # shellcheck source=/dev/null
         . /utils.sh
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-        echo '{}' > "$(results.SCAN_OUTPUT.path)"
 
         if [ ! -d "$SOURCE_PATH" ]; then
           note="Task $(context.task.name) failed: Source directory not found at $SOURCE_PATH."
@@ -168,7 +166,7 @@ spec:
           "${imageanddigest}" \
           "/tekton/home/picklescan-report.json:${MEDIA_TYPE}"
     - name: evaluate-policy
-      image: quay.io/konflux-ci/konflux-test:v1.5.3@sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455
+      image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
       computeResources:
         limits:
           memory: 256Mi

--- a/task/pickle-scan/CHANGELOG.md
+++ b/task/pickle-scan/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
 
+## 0.1.1
+
+### Removed
+
+- SCAN_OUTPUT result has been removed as it wasn't compatible with standardized Konflux UI
+
 ## 0.1
 
 ### Added


### PR DESCRIPTION
* Use the new v1.5.4 version of konflux-test image which contains the fix for the parse_picklescan_output (see https://github.com/konflux-ci/konflux-test/pull/866)
* The `SCAN_OUTPUT` standardized result is meant to be used in vulnerability scanning tasks and is expected to follow a standardized format
* This cannot be achieved by this task as it does not perform such an activity, so it is better to remove the result altogether

Signed-off-by: dirgim <kpavic@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
