### PR TITLE
Pin roxctl step image to static digest instead of param reference

### DIFF
--- a/task/roxctl-scan/0.1/roxctl-scan.yaml
+++ b/task/roxctl-scan/0.1/roxctl-scan.yaml
@@ -15,6 +15,9 @@ spec:
     - name: image-digest
       description: Image digest to scan.
       default: ""
+    - name: rox_image
+      description: This param is no longer used. Its value will be ignored.
+      default: ""
     - name: rox_central_endpoint
       description: The address:port tuple for RHACS Stackrox Central.
       type: string

--- a/task/roxctl-scan/0.1/roxctl-scan.yaml
+++ b/task/roxctl-scan/0.1/roxctl-scan.yaml
@@ -15,9 +15,6 @@ spec:
     - name: image-digest
       description: Image digest to scan.
       default: ""
-    - name: rox_image
-      description: Image providing the roxctl tool.
-      default: 'registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:d6d5e50d1deda1e7b232d4e3f60fda6f3d27266b6fc007c8ec48a324e1c6c15c'
     - name: rox_central_endpoint
       description: The address:port tuple for RHACS Stackrox Central.
       type: string
@@ -81,7 +78,7 @@ spec:
   steps:
     - name: exchange-service-account-token
       workingDir: /tekton/home
-      image: $(params.rox_image)
+      image: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:d6d5e50d1deda1e7b232d4e3f60fda6f3d27266b6fc007c8ec48a324e1c6c15c
       volumeMounts:
         - name: token-vol
           mountPath: /service-account-token
@@ -134,7 +131,7 @@ spec:
           exit 0
         fi
     - name: rox-image-scan
-      image: $(params.rox_image)
+      image: registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8@sha256:d6d5e50d1deda1e7b232d4e3f60fda6f3d27266b6fc007c8ec48a324e1c6c15c
       env:
         - name: HOME
           value: /tekton/home


### PR DESCRIPTION
Replace $(params.rox_image) with a pinned image digest in steps 0 and 2, and remove the rox_image param. Parameterized step image refs cannot be statically validated by Conforma task-definition policy checks, causing step_images_permitted and step_images_accessible violations.

Resolves: EC-1684

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
