### PR TITLE
feat(STONEINTG-1579): onboard pickle-scan-oci-ta-v01 component

### DIFF
--- a/.tekton/integration/test-pickle-scan-oci-ta.yaml
+++ b/.tekton/integration/test-pickle-scan-oci-ta.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: test-pickle-scan-oci-ta
+  labels:
+    appstudio.openshift.io/application: konflux-test-tasks
+    appstudio.openshift.io/component: pickle-scan-oci-ta-v01
+spec:
+  pipelineSpec:
+    description: |
+      Test the pickle-scan-oci-ta task by running it against a pre-existing
+      trusted artifact and validating the expected results structure.
+    results:
+      - name: TEST_OUTPUT
+        value: "$(tasks.check-results.results.TEST_OUTPUT)"
+    tasks:
+      - name: pickle-scan-oci-ta
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/konflux-ci/konflux-test-tasks.git
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
+        params:
+          # SOURCE_ARTIFACT is a real trusted artifact produced by the
+          # pickle-scan-v01 push build (the git source of this repository,
+          # which contains no pickle files, so the scan passes). To refresh
+          # it, pick the newest `<git-sha>.git` tag in the
+          # quay.io/redhat-user-workloads/rhtap-integration-tenant/pickle-scan-v01
+          # repository and use the digest of its single layer (the one
+          # annotated as SOURCE_ARTIFACT).
+          - name: SOURCE_ARTIFACT
+            value: "oci:quay.io/redhat-user-workloads/rhtap-integration-tenant/pickle-scan-v01@sha256:098c8ccd69441304a675fb1316e018448adc5a0bada4c1b332debc7f473d2e18"
+          - name: skip-oci-attach-report
+            value: "true"
+          - name: image-url
+            value: "quay.io/konflux-ci/konflux-test:v1.5.3"
+          - name: image-digest
+            value: "sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455"
+      - name: check-results
+        runAfter:
+          - pickle-scan-oci-ta
+        params:
+          - name: TEST_OUTPUT
+            value: "$(tasks.pickle-scan-oci-ta.results.TEST_OUTPUT)"
+          - name: IMAGES_PROCESSED
+            value: "$(tasks.pickle-scan-oci-ta.results.IMAGES_PROCESSED)"
+        taskSpec:
+          params:
+            - name: TEST_OUTPUT
+            - name: IMAGES_PROCESSED
+          results:
+            - name: TEST_OUTPUT
+              description: Test result output
+          steps:
+            - name: validate-results
+              image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
+              env:
+                - name: TEST_OUTPUT
+                  value: "$(params.TEST_OUTPUT)"
+                - name: IMAGES_PROCESSED
+                  value: "$(params.IMAGES_PROCESSED)"
+                - name: IMAGE_URL
+                  value: "quay.io/konflux-ci/konflux-test:v1.5.3"
+                - name: IMAGE_DIGEST
+                  value: "sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455"
+              script: |
+                #!/usr/bin/env bash
+                set -euo pipefail
+
+                echo "=== Validating pickle-scan-oci-ta task results ==="
+
+                # Validate TEST_OUTPUT structure
+                echo "--- Checking TEST_OUTPUT ---"
+                echo "$TEST_OUTPUT" | jq -e '
+                  has("result") and
+                  has("note") and
+                  has("timestamp") and
+                  (.result | IN("SUCCESS", "WARNING", "ERROR", "SKIPPED"))
+                ' > /dev/null || {
+                  echo "FAIL: TEST_OUTPUT missing required fields or invalid result"
+                  echo "Got: $TEST_OUTPUT"
+                  exit 1
+                }
+
+                result=$(echo "$TEST_OUTPUT" | jq -r '.result')
+                if [[ "$result" != "SUCCESS" ]]; then
+                  echo "FAIL: Expected result SUCCESS, got: $result"
+                  exit 1
+                fi
+                echo "PASS: TEST_OUTPUT is valid with result=$result"
+
+                failures=$(echo "$TEST_OUTPUT" | jq -r '.failures')
+                if [[ "$failures" != "0" ]]; then
+                  echo "FAIL: Expected 0 failures in TEST_OUTPUT, got: $failures"
+                  exit 1
+                fi
+                echo "PASS: TEST_OUTPUT is valid with failures=$failures"
+
+                successes=$(echo "$TEST_OUTPUT" | jq -r '.successes')
+                if [[ "$successes" != "1" ]]; then
+                  echo "FAIL: Expected 1 successes in TEST_OUTPUT, got: $successes"
+                  exit 1
+                fi
+                echo "PASS: TEST_OUTPUT is valid with successes=$successes"
+
+                # Validate IMAGES_PROCESSED structure
+                echo "--- Checking IMAGES_PROCESSED ---"
+                echo "$IMAGES_PROCESSED" | jq -e '
+                  has("image") and
+                  (.image | (has("pullspec") and has("digests"))) and
+                  (.image.digests | type) == "array" and
+                  (.image.digests | length) > 0
+                ' > /dev/null || {
+                  echo "FAIL: IMAGES_PROCESSED missing required fields"
+                  echo "Got: $IMAGES_PROCESSED"
+                  exit 1
+                }
+
+                # Verify pullspec matches input
+                pullspec=$(echo "$IMAGES_PROCESSED" | jq -r '.image.pullspec')
+                if [[ "$pullspec" != "$IMAGE_URL" ]]; then
+                  echo "FAIL: IMAGES_PROCESSED pullspec mismatch"
+                  echo "Expected: $IMAGE_URL"
+                  echo "Got: $pullspec"
+                  exit 1
+                fi
+
+                # Verify digest is in the list
+                if ! echo "$IMAGES_PROCESSED" | jq -e \
+                  --arg digest "$IMAGE_DIGEST" '.image.digests | index($digest) != null' > /dev/null; then
+                  echo "FAIL: IMAGE_DIGEST not found in IMAGES_PROCESSED digests"
+                  echo "Expected digest: $IMAGE_DIGEST"
+                  echo "Got digests: $(echo "$IMAGES_PROCESSED" | jq '.image.digests')"
+                  exit 1
+                fi
+                echo "PASS: IMAGES_PROCESSED is valid"
+                echo "$IMAGES_PROCESSED" | jq '.'
+
+                echo ""
+                echo "=== All pickle-scan-oci-ta validations passed ==="
+                echo -n "$TEST_OUTPUT" > "$(results.TEST_OUTPUT.path)"
+  timeouts:
+    pipeline: 1h0m0s
+    tasks: 45m0s

--- a/.tekton/pickle-scan-oci-ta-v01-pull-request.yaml
+++ b/.tekton/pickle-scan-oci-ta-v01-pull-request.yaml
@@ -1,0 +1,299 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/konflux-test-tasks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "task/pickle-scan-oci-ta/0.1/***".pathChanged() || ".tekton/pickle-scan-oci-ta-v01-pull-request.yaml".pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: konflux-test-tasks
+    appstudio.openshift.io/component: pickle-scan-oci-ta-v01
+    pipelines.appstudio.openshift.io/type: build
+  name: pickle-scan-oci-ta-v01-on-pull-request
+  namespace: rhtap-integration-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rhtap-integration-tenant/pickle-scan-oci-ta-v01:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: task/pickle-scan-oci-ta/0.1
+  pipelineSpec:
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description: Path to the source code of an application's component from where
+          to build image.
+        name: path-context
+        type: string
+      - default: Dockerfile
+        description: Path to the Dockerfile inside the context specified by parameter
+          path-context
+        name: dockerfile
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "false"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched
+        name: prefetch-input
+        type: string
+      - default: ""
+        description: Image tag expiration time, time values could be something like
+          1h, 2d, 3w for hours, days, and weeks, respectively.
+        name: image-expires-after
+        type: string
+      - default: "false"
+        description: Build a source image.
+        name: build-source-image
+        type: string
+      - default: "false"
+        description: Add built image into an OCI image index
+        name: build-image-index
+        type: string
+      - default: "false"
+        description: Enable cache proxy configuration
+        name: enable-cache-proxy
+      - name: enable-package-registry-proxy
+        default: 'true'
+        description: Use the package registry proxy when prefetching dependencies
+        type: string
+      - name: sast-target-dirs
+        type: string
+        default: .
+        description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        params:
+          - name: enable-cache-proxy
+            value: $(params.enable-cache-proxy)
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e5ba1f8549e6a0f043629ef00bea7511957121e05304b688f40ff12304560f38
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - name: prefetch-dependencies
+        params:
+          - name: input
+            value: $(params.prefetch-input)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+          - name: enable-package-registry-proxy
+            value: $(params.enable-package-registry-proxy)
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: prefetch-dependencies-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: git-basic-auth
+            workspace: git-auth
+          - name: netrc
+            workspace: netrc
+      - name: build-container
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: CONTEXT
+            value: $(params.path-context)
+          - name: URL
+            value: $(params.git-url)
+          - name: REVISION
+            value: $(params.revision)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        runAfter:
+          - prefetch-dependencies
+        taskRef:
+          params:
+            - name: name
+              value: tkn-bundle-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:9e5dce0c4b1808ef68ea2b5b77a67936576f82e5b773b5f8a3b7a7b494ebd94d
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: build-image-index
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: ALWAYS_BUILD_INDEX
+            value: $(params.build-image-index)
+          - name: IMAGES
+            value:
+              - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        runAfter:
+          - build-container
+        taskRef:
+          params:
+            - name: name
+              value: build-image-index
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:70c52e88e737340e7b58418fda38c13273aa7cdf587b825778e3560aca1d1133
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: sast-shell-check
+        params:
+          - name: image-digest
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: TARGET_DIRS
+            value: $(params.sast-target-dirs)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: sast-shell-check-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:f6a115eb88640f65d6c0e404c55cdd315755577fedf9958c4efd9af5180f6fc3
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: sast-unicode-check
+        params:
+          - name: image-digest
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: TARGET_DIRS
+            value: $(params.sast-target-dirs)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: sast-unicode-check-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:4961c44d6475f0343fe73c556a44204daa85d8c47e23f98d723255d1ff98271d
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: apply-tags
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: apply-tags
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:6387614ae4f9efa8abb7c4175db0ce5d958bc2b90665b4704880e46fbe0535bf
+            - name: kind
+              value: task
+          resolver: bundles
+    workspaces:
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pickle-scan-oci-ta-v01
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/pickle-scan-oci-ta-v01-push.yaml
+++ b/.tekton/pickle-scan-oci-ta-v01-push.yaml
@@ -1,0 +1,296 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/konflux-test-tasks?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "task/pickle-scan-oci-ta/0.1/***".pathChanged() || ".tekton/pickle-scan-oci-ta-v01-push.yaml".pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: konflux-test-tasks
+    appstudio.openshift.io/component: pickle-scan-oci-ta-v01
+    pipelines.appstudio.openshift.io/type: build
+  name: pickle-scan-oci-ta-v01-on-push
+  namespace: rhtap-integration-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/rhtap-integration-tenant/pickle-scan-oci-ta-v01:{{revision}}
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: task/pickle-scan-oci-ta/0.1
+  pipelineSpec:
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description: Path to the source code of an application's component from where
+          to build image.
+        name: path-context
+        type: string
+      - default: Dockerfile
+        description: Path to the Dockerfile inside the context specified by parameter
+          path-context
+        name: dockerfile
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "false"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched
+        name: prefetch-input
+        type: string
+      - default: ""
+        description: Image tag expiration time, time values could be something like
+          1h, 2d, 3w for hours, days, and weeks, respectively.
+        name: image-expires-after
+        type: string
+      - default: "false"
+        description: Build a source image.
+        name: build-source-image
+        type: string
+      - default: "false"
+        description: Add built image into an OCI image index
+        name: build-image-index
+        type: string
+      - default: "false"
+        description: Enable cache proxy configuration
+        name: enable-cache-proxy
+      - name: enable-package-registry-proxy
+        default: 'true'
+        description: Use the package registry proxy when prefetching dependencies
+        type: string
+      - name: sast-target-dirs
+        type: string
+        default: .
+        description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        params:
+          - name: enable-cache-proxy
+            value: $(params.enable-cache-proxy)
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e5ba1f8549e6a0f043629ef00bea7511957121e05304b688f40ff12304560f38
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - name: prefetch-dependencies
+        params:
+          - name: input
+            value: $(params.prefetch-input)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+          - name: enable-package-registry-proxy
+            value: $(params.enable-package-registry-proxy)
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: prefetch-dependencies-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: git-basic-auth
+            workspace: git-auth
+          - name: netrc
+            workspace: netrc
+      - name: build-container
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: CONTEXT
+            value: $(params.path-context)
+          - name: URL
+            value: $(params.git-url)
+          - name: REVISION
+            value: $(params.revision)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        runAfter:
+          - prefetch-dependencies
+        taskRef:
+          params:
+            - name: name
+              value: tkn-bundle-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:9e5dce0c4b1808ef68ea2b5b77a67936576f82e5b773b5f8a3b7a7b494ebd94d
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: build-image-index
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: ALWAYS_BUILD_INDEX
+            value: $(params.build-image-index)
+          - name: IMAGES
+            value:
+              - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        runAfter:
+          - build-container
+        taskRef:
+          params:
+            - name: name
+              value: build-image-index
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:70c52e88e737340e7b58418fda38c13273aa7cdf587b825778e3560aca1d1133
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: sast-shell-check
+        params:
+          - name: image-digest
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: TARGET_DIRS
+            value: $(params.sast-target-dirs)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: sast-shell-check-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:f6a115eb88640f65d6c0e404c55cdd315755577fedf9958c4efd9af5180f6fc3
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: sast-unicode-check
+        params:
+          - name: image-digest
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: TARGET_DIRS
+            value: $(params.sast-target-dirs)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: sast-unicode-check-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:4961c44d6475f0343fe73c556a44204daa85d8c47e23f98d723255d1ff98271d
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.skip-checks)
+            operator: in
+            values:
+              - "false"
+      - name: apply-tags
+        params:
+          - name: IMAGE_URL
+            value: $(tasks.build-image-index.results.IMAGE_URL)
+          - name: IMAGE_DIGEST
+            value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        runAfter:
+          - build-image-index
+        taskRef:
+          params:
+            - name: name
+              value: apply-tags
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:6387614ae4f9efa8abb7c4175db0ce5d958bc2b90665b4704880e46fbe0535bf
+            - name: kind
+              value: task
+          resolver: bundles
+    workspaces:
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-pickle-scan-oci-ta-v01
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Currently available integration tests:
 - `test-clamav-scan.yaml` - Validates the clamav-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-deprecated-image.yaml` - Validates the deprecated-image-check task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-pickle-scan.yaml` - Validates the pickle-scan task outputs (TEST_OUTPUT, IMAGES_PROCESSED)
+- `test-pickle-scan-oci-ta.yaml` - Validates the pickle-scan-oci-ta task outputs (TEST_OUTPUT, IMAGES_PROCESSED)
 - `test-roxctl-scan.yaml` - Validates the roxctl-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `test-tpa-scan.yaml` - Validates the tpa-scan task outputs (TEST_OUTPUT, SCAN_OUTPUT, IMAGES_PROCESSED, REPORTS)
 - `validate-migration.yaml` - Validates the migration file introduced by a branch

--- a/task/pickle-scan-oci-ta/0.1/kustomization.yaml
+++ b/task/pickle-scan-oci-ta/0.1/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pickle-scan-oci-ta.yaml

--- a/task/pickle-scan/0.1/README.md
+++ b/task/pickle-scan/0.1/README.md
@@ -28,3 +28,11 @@ code execution payloads.
 | Name | Description |
 |------|-------------|
 | TEST_OUTPUT | Tekton task test output |
+| IMAGES_PROCESSED | Images processed in the task |
+
+## Trusted Artifacts variant
+
+A Trusted Artifacts variant of this task,
+[pickle-scan-oci-ta](../../pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml),
+consumes the files to scan via the `SOURCE_ARTIFACT` parameter instead of
+the `source` workspace.


### PR DESCRIPTION
Add build PipelineRuns, kustomization.yaml, and integration test for pickle-scan-oci-ta task that was never onboarded as a Konflux component. Document IMAGES_PROCESSED and the TA variant in the base task README to trigger a release build on merge.


Assisted-by: Claude Code

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
