### PR TITLE
fix(STONEINTG-1580): remove absolute path in oras attach

### DIFF
--- a/task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
+++ b/task/pickle-scan-oci-ta/0.1/pickle-scan-oci-ta.yaml
@@ -173,7 +173,7 @@ spec:
         retry oras attach --no-tty --registry-config "/tmp/auth/config.json" \
           --artifact-type "${MEDIA_TYPE}" \
           "${imageanddigest}" \
-          "/tekton/home/picklescan-report.json:${MEDIA_TYPE}"
+          "picklescan-report.json:${MEDIA_TYPE}"
       computeResources:
         limits:
           cpu: 100m

--- a/task/pickle-scan/0.1/pickle-scan.yaml
+++ b/task/pickle-scan/0.1/pickle-scan.yaml
@@ -162,7 +162,7 @@ spec:
         retry oras attach --no-tty --registry-config "/tmp/auth/config.json" \
           --artifact-type "${MEDIA_TYPE}" \
           "${imageanddigest}" \
-          "/tekton/home/picklescan-report.json:${MEDIA_TYPE}"
+          "picklescan-report.json:${MEDIA_TYPE}"
     - name: evaluate-policy
       image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
       computeResources:


### PR DESCRIPTION
Fix -  Error: absolute file path detected. If it's intentional, use --disable-path-validation flag to skip this check: /tekton/home/picklescan-report.json

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
