### PR TITLE
fix(STONEINTG-1680): resolve image reference inconsistencies in roxctl-scan

### DIFF
--- a/.tekton/integration/test-roxctl-scan.yaml
+++ b/.tekton/integration/test-roxctl-scan.yaml
@@ -26,7 +26,7 @@ spec:
           - name: skip-upload
             value: "true"
           - name: image-url
-            value: "quay.io/konflux-ci/konflux-test:v1.5.4"
+            value: "quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b"
           - name: image-digest
             value: "sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b"
       - name: check-results
@@ -51,7 +51,7 @@ spec:
             - name: TEST_OUTPUT
           steps:
             - name: validate-results
-              image: quay.io/konflux-ci/konflux-test:v1.5.4
+              image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
               env:
                 - name: TEST_OUTPUT
                   value: "$(params.TEST_OUTPUT)"
@@ -62,7 +62,7 @@ spec:
                 - name: REPORTS
                   value: "$(params.REPORTS)"
                 - name: IMAGE_URL
-                  value: "quay.io/konflux-ci/konflux-test:v1.5.4"
+                  value: "quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b"
               script: |
                 #!/usr/bin/env bash
                 set -euo pipefail

--- a/.tekton/integration/test-roxctl-scan.yaml
+++ b/.tekton/integration/test-roxctl-scan.yaml
@@ -26,7 +26,7 @@ spec:
           - name: skip-upload
             value: "true"
           - name: image-url
-            value: "quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b"
+            value: "quay.io/konflux-ci/konflux-test:v1.5.4"
           - name: image-digest
             value: "sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b"
       - name: check-results
@@ -62,7 +62,7 @@ spec:
                 - name: REPORTS
                   value: "$(params.REPORTS)"
                 - name: IMAGE_URL
-                  value: "quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b"
+                  value: "quay.io/konflux-ci/konflux-test:v1.5.4"
               script: |
                 #!/usr/bin/env bash
                 set -euo pipefail

--- a/task/roxctl-scan/0.1/roxctl-scan.yaml
+++ b/task/roxctl-scan/0.1/roxctl-scan.yaml
@@ -203,7 +203,7 @@ spec:
         images_processed=$(echo "${images_processed_template/\[%s]/[$digests_processed_string]}")
         echo "$images_processed" > images-processed.json
     - name: oci-attach-report
-      image: quay.io/konflux-ci/oras:latest@sha256:6b8e8b368bdaad521629300a6d945734a15207fa5070a0396d42b377cf6c61fb
+      image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
       workingDir: /tekton/home
       env:
         - name: IMAGE_URL


### PR DESCRIPTION
Replaces the oras image with **task-runner** in the **oci-attach-report step** of **roxctl-scan** and adds digest references to the konflux-test image in the integration test pipeline. Added missing digest across digest reference to the konflux-test image across all three occurrences

Note: **clair-scan/0.2**, **clamav-scan/0.1** and **clamav-scan/0.2** also reference the old oras image but these older versions were confirmed out of scope.